### PR TITLE
Adding fixed atom constraints for NVT simulations

### DIFF
--- a/deepmd_jax/md.py
+++ b/deepmd_jax/md.py
@@ -326,7 +326,7 @@ class Simulation:
         )
 
         # Create mask for constraining atoms
-        mobile = np.ones((self._natoms, 3), dtype=np.float32)
+        mobile = np.ones(self._natoms)
         if fixed_indices is not None:
             mobile[fixed_indices] = 0.0
         mobile = jnp.array(mobile)

--- a/deepmd_jax/md.py
+++ b/deepmd_jax/md.py
@@ -332,7 +332,7 @@ class Simulation:
         mobile = jnp.array(mobile)
 
         # Define masked shift function
-        self._shift_fn = lambda x, dx: jnp.where(mobile[:, None], shift(x, dx), x)
+        self._shift_fn = lambda x, dx, **kwargs: jnp.where(mobile[:, None], shift(x, dx, **kwargs), x)
 
         # Initialize according to routine;
         if self._routine == "NVE":

--- a/deepmd_jax/md.py
+++ b/deepmd_jax/md.py
@@ -91,6 +91,35 @@ def get_idx_mask_fn(type_count):
         return jnp.where(filter, idx, len(full_mask))
     return idx_mask_fn
 
+def _nvt_nose_hoover_invariant(energy_fn,
+                    state: jax_md.simulate.NVTNoseHooverState,
+                    kT: float,
+                    **kwargs) -> float:
+    """The conserved quantity for the NVT ensemble with a Nose-Hoover thermostat.
+
+    This function is adapted from jax_md.simulate to define the DOF differently.
+
+    Arguments:
+        energy_fn: The energy function of the Nose-Hoover system.
+        state: The current state of the system.
+        kT: The current goal temperature of the system.
+
+    Returns:
+        The Hamiltonian of the extended NVT dynamics.
+    """
+    PE = energy_fn(state.position, **kwargs)
+    KE = jax_md.simulate.kinetic_energy(state)
+
+    DOF = state.chain.degrees_of_freedom
+    E = PE + KE
+
+    c = state.chain
+
+    E += c.momentum[0] ** 2 / (2 * c.mass[0]) + DOF * kT * c.position[0]
+    for r, p, m in zip(c.position[1:], c.momentum[1:], c.mass[1:]):
+        E += p ** 2 / (2 * m) + kT * r
+    return E
+
 @jax_md.dataclasses.dataclass
 class TypedNeighborList():
     '''
@@ -574,7 +603,7 @@ class Simulation:
                                             self._reporters["KE"](state, nbrs_nm) + \
                                             self._reporters["PE"](state, nbrs_nm)
         elif self._routine == "NVT":
-            self._reporters["Invariant"] = lambda state, nbrs_nm: jax_md.simulate.nvt_nose_hoover_invariant(
+            self._reporters["Invariant"] = lambda state, nbrs_nm: _nvt_nose_hoover_invariant(
                                             self._energy_fn,
                                             state,
                                             self._temperature * TEMP_UNIT_CONVERSION,

--- a/deepmd_jax/md.py
+++ b/deepmd_jax/md.py
@@ -355,8 +355,11 @@ class Simulation:
         else: 
             self._mobile = None
 
+        if self._mobile is not None and self._routine != 'NVT':
+            raise NotImplementedError("Fixing atoms currently limited to NVT")
+
         def _shift_fn_wrapper(x, dx, **kwargs):
-            if mobile is not None:
+            if self._mobile is not None:
                 return jnp.where(mobile[:, None], shift(x, dx, **kwargs), x)
             else:
                 return shift(x, dx, **kwargs)
@@ -919,6 +922,8 @@ class Simulation:
         '''
             Set the velocity (Å/fs) of the atoms. Must be the same shape as the initial position representing the same system.
         '''
+        if self._mobile is not None:
+            velocity = velocity * self._mobile[:, None]
         self._state = self._state.set(momentum=self._state.mass * velocity)
 
     def getBox(self):

--- a/deepmd_jax/train.py
+++ b/deepmd_jax/train.py
@@ -94,7 +94,7 @@ def train(
     
     TIC = time.time()
     if jax.device_count() > 1:
-        print('# Note: Currently only one device will be used for training.')
+        print('# Note: Currently only one device will be used for training.', flush=True)
 
     # width check
     if fit_widths is None:
@@ -114,7 +114,7 @@ def train(
                 raise ValueError('embed_mp_widths[i] must divide or be divisible by embed_mp_widths[i+1]')
     for i in range(len(fit_widths)-1):
         if fit_widths[i+1] != fit_widths[i] != 0:
-            print('# Warning: it is recommended to use the same width for all layers in the fitting network.')
+            print('# Warning: it is recommended to use the same width for all layers in the fitting network.', flush=True)
     if model_type == 'atomic':
         if mp:
             if embed_mp_widths[-1] != fit_widths[-1]:
@@ -220,7 +220,7 @@ def train(
         }
         params.update(dplr_params)
     model = DPModel(params)
-    print('# Model params:', model.params)
+    print('# Model params:', model.params, flush=True)
 
     # initialize model variables
     batch, type_count, lattice_args = train_data.get_batch(1)
@@ -234,7 +234,7 @@ def train(
                     static_args,
                 )
     print('# Model initialized with parameter count %d.' %
-           sum(i.size for i in jax.tree_util.tree_flatten(variables)[0]))
+           sum(i.size for i in jax.tree_util.tree_flatten(variables)[0]), flush=True)
     
     # initialize optimizer
     if lr is None:
@@ -251,7 +251,7 @@ def train(
     optimizer = optax.adam(learning_rate = lr_scheduler,
                            b2 = beta2)
     opt_state = optimizer.init(variables)
-    print('# Optimizer initialized with initial lr = %.1e. Starting training...' % lr)
+    print('# Optimizer initialized with initial lr = %.1e. Starting training...' % lr, flush=True)
 
     # define training step
     loss_fn, loss_and_grad_fn = model.get_loss_fn()
@@ -301,9 +301,9 @@ def train(
         
     # configure batch size
     if batch_size is None:
-        print(f'# Auto batch size = int({label_bs}/nlabels_per_frame)')
+        print(f'# Auto batch size = int({label_bs}/nlabels_per_frame)', flush=True)
     else:
-        print(f'# Batch size = {batch_size}')
+        print(f'# Batch size = {batch_size}', flush=True)
     def get_batch_train():
         if batch_size is None:
             return train_data.get_batch(label_bs, 'label')
@@ -333,7 +333,7 @@ def train(
             else:
                 line += f' Lval {np.array(loss_val).mean() ** 0.5:7.5f}'
         line += f' Time {time.time() - tic:.2f}s'
-        print(line)
+        print(line, flush=True)
 
     # training loop
     tic = time.time()
@@ -365,7 +365,7 @@ def train(
                                                 compress_Ngrids,
                                                 compress_r_min)
     save_model(save_path, model, variables)
-    print(f'# Training finished in {datetime.timedelta(seconds=int(time.time() - TIC))}.')
+    print(f'# Training finished in {datetime.timedelta(seconds=int(time.time() - TIC))}.', flush=True)
 
 def test(
     model_path: str,

--- a/deepmd_jax/train.py
+++ b/deepmd_jax/train.py
@@ -94,7 +94,7 @@ def train(
     
     TIC = time.time()
     if jax.device_count() > 1:
-        print('# Note: Currently only one device will be used for training.', flush=True)
+        print('# Note: Currently only one device will be used for training.')
 
     # width check
     if fit_widths is None:
@@ -114,7 +114,7 @@ def train(
                 raise ValueError('embed_mp_widths[i] must divide or be divisible by embed_mp_widths[i+1]')
     for i in range(len(fit_widths)-1):
         if fit_widths[i+1] != fit_widths[i] != 0:
-            print('# Warning: it is recommended to use the same width for all layers in the fitting network.', flush=True)
+            print('# Warning: it is recommended to use the same width for all layers in the fitting network.')
     if model_type == 'atomic':
         if mp:
             if embed_mp_widths[-1] != fit_widths[-1]:
@@ -220,7 +220,7 @@ def train(
         }
         params.update(dplr_params)
     model = DPModel(params)
-    print('# Model params:', model.params, flush=True)
+    print('# Model params:', model.params)
 
     # initialize model variables
     batch, type_count, lattice_args = train_data.get_batch(1)
@@ -234,7 +234,7 @@ def train(
                     static_args,
                 )
     print('# Model initialized with parameter count %d.' %
-           sum(i.size for i in jax.tree_util.tree_flatten(variables)[0]), flush=True)
+           sum(i.size for i in jax.tree_util.tree_flatten(variables)[0]))
     
     # initialize optimizer
     if lr is None:
@@ -251,7 +251,7 @@ def train(
     optimizer = optax.adam(learning_rate = lr_scheduler,
                            b2 = beta2)
     opt_state = optimizer.init(variables)
-    print('# Optimizer initialized with initial lr = %.1e. Starting training...' % lr, flush=True)
+    print('# Optimizer initialized with initial lr = %.1e. Starting training...' % lr)
 
     # define training step
     loss_fn, loss_and_grad_fn = model.get_loss_fn()
@@ -301,9 +301,9 @@ def train(
         
     # configure batch size
     if batch_size is None:
-        print(f'# Auto batch size = int({label_bs}/nlabels_per_frame)', flush=True)
+        print(f'# Auto batch size = int({label_bs}/nlabels_per_frame)')
     else:
-        print(f'# Batch size = {batch_size}', flush=True)
+        print(f'# Batch size = {batch_size}')
     def get_batch_train():
         if batch_size is None:
             return train_data.get_batch(label_bs, 'label')
@@ -333,7 +333,7 @@ def train(
             else:
                 line += f' Lval {np.array(loss_val).mean() ** 0.5:7.5f}'
         line += f' Time {time.time() - tic:.2f}s'
-        print(line, flush=True)
+        print(line)
 
     # training loop
     tic = time.time()
@@ -365,7 +365,7 @@ def train(
                                                 compress_Ngrids,
                                                 compress_r_min)
     save_model(save_path, model, variables)
-    print(f'# Training finished in {datetime.timedelta(seconds=int(time.time() - TIC))}.', flush=True)
+    print(f'# Training finished in {datetime.timedelta(seconds=int(time.time() - TIC))}.')
 
 def test(
     model_path: str,


### PR DESCRIPTION
Hello,

First of all, really nice job on this lightweight package and using JAX-MD is also a cool idea. 

I'm interested in doing simulations with a slab geometry where the bottom atoms of the slabs are fixed. There's no native functionality for this in JAX-MD but I tried to implement it with a wrapper.

Initially I just wrapped the `shift_fn` from
```
self._displacement_fn, self._shift_fn = jax_md.space.periodic_general(self._initial_box, fractional_coordinates="NPT" in self._routine)
```
with a masked shift function (see [this thread](https://github.com/jax-md/jax-md/issues/115)), but this doesn't work for NVT simulations. In fact, when I tried it, all atoms in the simulation slowly froze. The JAX-MD issue thread also suggested that the reason is that degrees of freedom aren't properly accounted for. With the help of ChatGPT I ended up with a wrapper function that corrects the DoF and sets the momentum of constrained atoms to zero after the NVT function update. 

This is more of a draft PR - I'm a beginner when it comes to MD simulation code so I'd greatly appreciate any help. In particular,

* any idea whether this approach is physically sound?
* would it be a good idea to apply the wrapper to all of the NVE, NVT and NPT simulation routines?
* any things I should test in particular to verify the code? 
* should the wrapped init and apply functions be jitted? (in my test, it didn't seem to affect speed, but maybe it does for bigger systems) 

