### PR TITLE
Read extxyz files

### DIFF
--- a/deepmd_jax/data.py
+++ b/deepmd_jax/data.py
@@ -3,6 +3,7 @@ import jax.numpy as jnp
 from jax import vmap
 from glob import glob
 from os.path import abspath
+from ase.io import read
 from .utils import shift, get_relative_coord, sr
 
 class DPDataset():
@@ -49,7 +50,7 @@ class DPDataset():
                         assert self.data[l].shape[2] in (3, 9)
                     except:
                         raise ValueError('Atomic label must have 3 (vector) or 9 (3x3 tensor) components per atom.')
-                    sel_type = self.type[np.in1d(self.type, self.nsel)]
+                    sel_type = self.type[np.isin(self.type, self.nsel)]
                     self.data[l] = self.data[l][:,sel_type.argsort(kind='stable')]
             self.data['box'] = self.data['box'].reshape(-1,3,3)
             self.data['coord'] = np.array(vmap(shift)(self.data['coord'], self.data['box']))
@@ -140,6 +141,164 @@ class DPDataset():
             return [{'data':self.data, 'type_count':self.type_count, 'lattice_args':self.lattice_args}]
         else:
             return sum([subset.get_flattened_data() for subset in self.subsets], [])
+
+class EXTXYZDataset():
+    def __init__(self, paths, labels, params={}):
+        if type(paths[0]) == list:
+            self.is_leaf = False
+            self.subsets = [EXTXYZDataset(path, labels, params) for path in paths]
+            self.nframes = sum([subset.nframes for subset in self.subsets])
+            self.ntypes = max([subset.ntypes for subset in self.subsets])
+            [subset.fill_type(self.ntypes) for subset in self.subsets]
+            self.prob = np.array([subset.nframes for subset in self.subsets]) / self.nframes
+            self.type_count = self.count_max()
+            self.valid_types = np.arange(self.ntypes)[self.type_count > 0]
+        else:
+            self.is_leaf = True
+            self.labels = labels
+            self.params = params
+            self.frames = []
+            self.paths = paths
+            for path in paths:
+                atoms_list = read(path, index=':')
+                if not isinstance(atoms_list, list):
+                    atoms_list = [atoms_list]
+                for atoms in atoms_list:
+                    frame = {}
+                    frame['coord'] = np.asarray(atoms.get_positions(), dtype=np.float32)
+                    frame['box'] = np.asarray(atoms.get_cell(), dtype=np.float32)
+                    frame['atomic_numbers'] = np.asarray(atoms.get_atomic_numbers(), dtype=int)
+                    if 'force' in labels:
+                        if 'forces' in atoms.arrays:
+                            frame['force'] = np.asarray(atoms.arrays['forces'], dtype=np.float32)
+                        else:
+                            raise ValueError('Extended xyz file missing forces for frame in %s' % path)
+                    if 'energy' in labels:
+                        energy = atoms.info.get('energy', None)
+                        if energy is None:
+                            raise ValueError('Extended xyz file missing energy for frame in %s' % path)
+                        frame['energy'] = np.asarray(energy, dtype=np.float32)
+                    for l in labels:
+                        if 'atomic' in l and l not in frame:
+                            if l in atoms.arrays:
+                                frame[l] = np.asarray(atoms.arrays[l], dtype=np.float32)
+                            else:
+                                raise ValueError('Atomic label %s not found in frame arrays for %s' % (l, path))
+                    if 'cell' in labels and 'cell' not in frame:
+                        frame['cell'] = frame['box']
+                    if 'type' in labels and 'type' not in frame:
+                        frame['type'] = frame['atomic_numbers']
+                    self.frames.append(frame)
+            # Map atomic numbers to types
+            all_atomic_numbers = set()
+            for frame in self.frames:
+                all_atomic_numbers.update(frame['atomic_numbers'])
+            unique_atomic_numbers = sorted(all_atomic_numbers)
+            self.atomic_to_type = {an: i for i, an in enumerate(unique_atomic_numbers)}
+            self.ntypes = len(unique_atomic_numbers)
+            self.valid_types = np.arange(self.ntypes)
+            for frame in self.frames:
+                frame['type'] = np.array([self.atomic_to_type[an] for an in frame['atomic_numbers']], dtype=int)
+            self.nframes = len(self.frames)
+            self.order = np.arange(self.nframes)
+            self.pointer = self.nframes
+            self.natoms = max([frame['coord'].shape[0] for frame in self.frames]) if self.frames else 0
+            print('# EXTXYZ Dataset loaded: %d frames. Path:' % self.nframes,
+                  ''.join(['\n# \t\'%s\'' % abspath(path) for path in paths]))
+
+    def count_max(self):
+        if self.is_leaf:
+            type_counts = []
+            for frame in self.frames:
+                tc = np.array([(frame['type'] == i).sum() for i in range(self.ntypes)])
+                type_counts.append(tc)
+            return np.array(type_counts).max(0)
+        else:
+            return np.array([subset.count_max() for subset in self.subsets]).max(0)
+
+    def fill_type(self, ntypes):
+        if not self.is_leaf:
+            [subset.fill_type(ntypes) for subset in self.subsets]
+        else:
+            self.ntypes = ntypes
+            self.valid_types = np.arange(self.ntypes)
+
+    def get_batch(self, batch_size, type='frame'):
+        if not self.is_leaf:
+            subset = np.random.choice(len(self.subsets), p=self.prob)
+            return self.subsets[subset].get_batch(batch_size, type)
+        else:
+            batch_size = 1
+            if self.pointer + batch_size > self.nframes:
+                self.pointer = 0
+                np.random.shuffle(self.order)
+            index = self.order[self.pointer]
+            self.pointer += batch_size
+            batch = self.frames[index]
+            # Compute type_count for the single frame based on mapped types
+            types = batch['type']
+            type_count = np.array([(types == i).sum() for i in range(self.ntypes)])
+            return batch, tuple(type_count), self.lattice_args
+
+    def compute_lattice_candidate(self, rcut):
+        if not self.is_leaf:
+            for subset in self.subsets:
+                subset.compute_lattice_candidate(rcut)
+        else:
+            boxes = np.stack([frame['box'] for frame in self.frames])
+            self.lattice_args = compute_lattice_candidate(boxes, rcut)
+
+    def get_flattened_data(self):
+        if self.is_leaf:
+            return [{'data':frame, 'lattice_args':self.lattice_args} for frame in self.frames]
+        else:
+            return sum([subset.get_flattened_data() for subset in self.subsets], [])
+
+    def fit_energy(self):
+        energy_stats = self._get_energy_stats()
+        type_counts, energies = [np.array(x) for x in zip(*energy_stats)]
+        return np.linalg.lstsq(type_counts, energies, rcond=1e-3)[0].astype(np.float32)
+    
+    def get_atomic_label_scale(self):
+        if not self.is_leaf:
+            return (np.array([subset.get_atomic_label_scale() for subset in self.subsets]) * np.array(self.prob)).sum()
+        else:
+            label = [l for l in self.frames[0].keys() if 'atomic' in l][0]
+            all_labels = np.concatenate([frame[label].flatten() for frame in self.frames])
+            return np.std(all_labels)
+
+    def _get_energy_stats(self):
+        if self.is_leaf:
+            return [(np.array([(frame['type'] == i).sum() for i in range(self.ntypes)]), frame['energy']) for frame in self.frames]
+        else:
+            return sum([subset._get_energy_stats() for subset in self.subsets], [])
+
+    def _get_stats(self, rcut, bs):
+        if self.is_leaf:
+            batch, type_count, lattice_args = self.get_batch(bs)
+            coord, box = batch['coord'], batch['box']
+            type_count = np.array(type_count)
+            r_Bnm = vmap(get_relative_coord,(0,0,None,None))(coord, box, type_count, lattice_args)[1]
+            sr_BnM = [sr(jnp.concatenate(r,axis=-1), rcut) for r in r_Bnm]
+            sr_sum = np.array([sr.sum() for sr in sr_BnM])
+            sr_sum2 = np.array([(sr**2).sum() for sr in sr_BnM])
+            sr_count = np.array([(sr>1e-15).sum() for sr in sr_BnM])
+            Nnbrs = (np.concatenate(sr_BnM, axis=1) > 0).sum(2).mean() + 1
+            return np.array([sr_sum, sr_sum2, sr_count, Nnbrs*np.ones_like(sr_sum)]) # (4, ntypes)
+        else:
+            s = np.stack([subset._get_stats(rcut, bs) for subset in self.subsets], axis=-1)
+            return (s * self.prob).sum(-1)
+        
+    def get_stats(self, rcut, bs):
+        self.params = {'ntypes': self.ntypes, 'rcut': rcut}
+        sr_sum, sr_sum2, sr_count, Nnbrs = self._get_stats(rcut, bs)
+        sr_sum, sr_sum2, sr_count = sr_sum[self.valid_types], sr_sum2[self.valid_types], sr_count[self.valid_types]
+        self.params['valid_types'] = self.valid_types
+        self.params['sr_mean'] = sr_sum / sr_count
+        self.params['sr_std'] = np.sqrt(sr_sum2 / sr_count - self.params['sr_mean']**2)
+        self.params['Nnbrs'] = Nnbrs[0]
+        return self.params
+
 
 def compute_lattice_candidate(boxes, rcut, print_info=True, disable_ortho=False): # boxes (nframes,3,3)
     N = 2  # This algorithm is heuristic and subject to change. Increase N in case of missing neighbors.

--- a/deepmd_jax/data.py
+++ b/deepmd_jax/data.py
@@ -19,9 +19,7 @@ def _flatten_paths(paths):
             yield p
 
 
-def Dataset(paths, labels, params=None, chemical_types=None, _in_memory=None):
-    if _in_memory is not None:
-        return DatasetLeaf(labels, params or {}, _in_memory['type'], _in_memory['data'])
+def Dataset(paths, labels, params=None, chemical_types=None):
     if isinstance(paths[0], list):
         subsets = [Dataset(path, labels, params, chemical_types) for path in paths]
         return DatasetGroup(subsets, chemical_types)

--- a/deepmd_jax/data.py
+++ b/deepmd_jax/data.py
@@ -20,6 +20,58 @@ def _flatten_paths(paths):
 
 
 def Dataset(paths, labels, params=None, chemical_types=None):
+    """
+    Create a dataset object from file paths.
+
+    This function dispatches to the appropriate dataset class based on the input paths
+    and formats. It supports DeepMD (DP) format (.npy files in directories) and
+    extended XYZ format (.xyz/.extxyz files).
+
+    Parameters
+    ----------
+    paths : str, list of str, or list of list of str
+        File paths to load data from. For DP format, paths should be strings pointing
+        to directories containing 'type.raw' and 'set.*/' subdirectories with .npy files.
+        For extxyz format, paths should be strings ending in '.xyz' or '.extxyz'.
+        If paths[0] is a list, it creates a composite dataset from multiple subsets.
+    labels : list of str
+        List of data labels to load, e.g., ['coord', 'energy', 'force'].
+    params : dict, optional
+        Additional parameters for dataset configuration, such as 'atomic_sel'.
+    chemical_types : list of int, optional
+        List of atomic numbers defining the chemical types. If None, inferred from data.
+
+    Returns
+    -------
+    DatasetLeaf, DatasetGroup, ExtXYZDataset, or DPDataset
+        - DatasetLeaf: For single composition groups.
+        - DatasetGroup: For composite datasets with multiple subsets.
+        - ExtXYZDataset: For extxyz files, groups frames by composition into DatasetLeaf subsets.
+        - DPDataset: For DP format directories.
+
+    Notes
+    -----
+    Dispatch Rules:
+    - If paths[0] is a list, recursively creates subsets and returns DatasetGroup.
+    - Otherwise, determines format from file extensions:
+        - extxyz: Returns ExtXYZDataset (supports multiple files, groups by composition).
+        - dp: Returns DPDataset.
+
+    Constraints:
+    - Mixing DP directories and extxyz files in the same paths list is not supported.
+    - All paths must be of the same format unless using list-of-lists for subsets.
+
+    Examples
+    --------
+    Load DP data:
+    >>> ds = Dataset(['path/to/dp/dir'], ['coord', 'energy'])
+
+    Load extxyz data:
+    >>> ds = Dataset(['file.xyz'], ['coord', 'energy', 'force'])
+
+    Create composite dataset:
+    >>> ds = Dataset([['file1.xyz'], ['file2.xyz']], ['coord', 'energy'])
+    """
     if isinstance(paths[0], list):
         subsets = [Dataset(path, labels, params, chemical_types) for path in paths]
         return DatasetGroup(subsets, chemical_types)
@@ -32,6 +84,41 @@ def Dataset(paths, labels, params=None, chemical_types=None):
 
 
 class DatasetLeaf:
+    """
+    Internal dataset class for in-memory data of a single composition.
+
+    A "leaf" dataset holds data for one composition group without subsets.
+    Used internally by ExtXYZDataset and DPDataset; not for direct user instantiation.
+
+    Parameters
+    ----------
+    labels : list of str
+        Data labels, e.g., ['coord', 'energy'].
+    params : dict
+        Configuration parameters.
+    type_arr : array-like
+        Atom types for each atom.
+    data : dict
+        Data dictionary with required 'coord' (nframes, natoms, 3) and 'box' (nframes, 3, 3).
+        Other labels like 'energy' (nframes,), 'force' (nframes, natoms, 3) optional.
+    paths : list of str, optional
+        File paths for logging.
+
+    Attributes
+    ----------
+    type : ndarray
+        Sorted atom types (int array).
+    type_count : ndarray
+        Count of each atom type.
+    valid_types : ndarray
+        Indices of types that appear in data.
+    data : dict
+        Processed data arrays, sorted by atom type.
+
+    Notes
+    -----
+    Lifecycle: Call compute_lattice_candidate(rcut) before get_stats(rcut, bs).
+    """
     def __init__(self, labels, params, type_arr, data, paths=None):
         self.chemical_types = getattr(self, 'chemical_types', None)
         self.type = np.array(type_arr, dtype=int)
@@ -144,6 +231,29 @@ class DatasetLeaf:
 
 
 class DPDataset(DatasetLeaf):
+    """
+    Dataset for DeepMD (DP) format directories.
+
+    Loads data from DP training directories containing type.raw and set.*/ subdirs
+    with .npy files. Concatenates data across all sets and directories.
+
+    Parameters
+    ----------
+    paths : list of str
+        Paths to DP directories. Each should contain 'type.raw' and 'set.*/' subdirs
+        with .npy files (e.g., coord.npy, energy.npy).
+    labels : list of str
+        Data labels to load.
+    params : dict, optional
+        Configuration parameters.
+    chemical_types : list of int, optional
+        Atomic numbers; inferred if None.
+
+    Notes
+    -----
+    Directory structure: path/type.raw, path/set.000/, path/set.001/, etc.
+    Each set.*/ contains label.npy files. Data is concatenated over all sets/paths.
+    """
     def __init__(self, paths, labels, params=None, chemical_types=None):
         self.chemical_types = tuple(chemical_types) if chemical_types else None
         type_arr = np.genfromtxt(paths[0] + '/type.raw').astype(int)
@@ -157,6 +267,13 @@ class DPDataset(DatasetLeaf):
 
 
 class DatasetGroup:
+    """
+    Composite dataset made from multiple subset datasets.
+
+    A DatasetGroup represents a mixture of DatasetLeaf subsets. Sampling across
+    subsets is weighted by subset size, stored in self.prob, so larger subsets are
+    selected more often during batch generation.
+    """
     def __init__(self, subsets, chemical_types=None):
         self.subsets = subsets
         self.chemical_types = tuple(chemical_types) if chemical_types else None
@@ -224,6 +341,33 @@ class DatasetGroup:
 
 
 class ExtXYZDataset(DatasetGroup):
+    """
+    Dataset for extended XYZ (.xyz/.extxyz) files.
+
+    Parses frames using ASE and groups them by composition before constructing
+    internal DatasetLeaf subsets. Each composition group becomes one leaf,
+    permitting multiple leaf datasets inside this composite DatasetGroup.
+
+    Parameters
+    ----------
+    paths : list of str
+        Paths to .xyz or .extxyz files.
+    labels : list of str
+        Data labels to load from each frame.
+    params : dict, optional
+        Configuration parameters forwarded to DatasetLeaf.
+    chemical_types : list of int, optional
+        Atomic numbers defining the type ordering. If None, inferred from all
+        atoms in the input files.
+
+    Notes
+    -----
+    - ASE reads each frame via `read(path, index=':')`.
+    - `chemical_types` is inferred from all atomic numbers present, or validated
+      against provided chemical_types.
+    - Frames are grouped by composition using a type-count tuple (`type_count`).
+    - Each distinct composition produces a separate DatasetLeaf internally.
+    """
     def __init__(self, paths, labels, params=None, chemical_types=None):
         raw_frames = []
         all_zs = set()

--- a/deepmd_jax/data.py
+++ b/deepmd_jax/data.py
@@ -1,5 +1,3 @@
-from operator import index
-
 import numpy as np
 import jax.numpy as jnp
 from jax import vmap
@@ -52,7 +50,7 @@ class DPDataset():
                         assert self.data[l].shape[2] in (3, 9)
                     except:
                         raise ValueError('Atomic label must have 3 (vector) or 9 (3x3 tensor) components per atom.')
-                    sel_type = self.type[np.isin(self.type, self.nsel)]
+                    sel_type = self.type[np.in1d(self.type, self.nsel)]
                     self.data[l] = self.data[l][:,sel_type.argsort(kind='stable')]
             self.data['box'] = self.data['box'].reshape(-1,3,3)
             self.data['coord'] = np.array(vmap(shift)(self.data['coord'], self.data['box']))

--- a/deepmd_jax/data.py
+++ b/deepmd_jax/data.py
@@ -29,11 +29,11 @@ def Dataset(paths, labels, params=None, chemical_types=None):
 
     Parameters
     ----------
-    paths : str, list of str, or list of list of str
+    paths : str or list of str
         File paths to load data from. For DP format, paths should be strings pointing
         to directories containing 'type.raw' and 'set.*/' subdirectories with .npy files.
         For extxyz format, paths should be strings ending in '.xyz' or '.extxyz'.
-        If paths[0] is a list, it creates a composite dataset from multiple subsets.
+        If paths is a list, it creates a composite dataset from multiple subsets.
     labels : list of str
         List of data labels to load, e.g., ['coord', 'energy', 'force'].
     params : dict, optional
@@ -47,19 +47,10 @@ def Dataset(paths, labels, params=None, chemical_types=None):
         - DatasetLeaf: For single composition groups.
         - DatasetGroup: For composite datasets with multiple subsets.
         - ExtXYZDataset: For extxyz files, groups frames by composition into DatasetLeaf subsets.
-        - DPDataset: For DP format directories.
-
-    Notes
-    -----
-    Dispatch Rules:
-    - If paths[0] is a list, recursively creates subsets and returns DatasetGroup.
-    - Otherwise, determines format from file extensions:
-        - extxyz: Returns ExtXYZDataset (supports multiple files, groups by composition).
-        - dp: Returns DPDataset.
+        - DPDataset: For a DP format directory.
 
     Constraints:
     - Mixing DP directories and extxyz files in the same paths list is not supported.
-    - All paths must be of the same format unless using list-of-lists for subsets.
 
     Examples
     --------
@@ -70,17 +61,24 @@ def Dataset(paths, labels, params=None, chemical_types=None):
     >>> ds = Dataset(['file.xyz'], ['coord', 'energy', 'force'])
 
     Create composite dataset:
-    >>> ds = Dataset([['file1.xyz'], ['file2.xyz']], ['coord', 'energy'])
+    >>> ds = Dataset(['file1.xyz', 'file2.xyz'], ['coord', 'energy'])
     """
-    if isinstance(paths[0], list):
-        subsets = [Dataset(path, labels, params, chemical_types) for path in paths]
-        return DatasetGroup(subsets, chemical_types)
-    formats = {_classify_path(p) for p in _flatten_paths(paths)}
+    if isinstance(paths, str) or len(paths) == 1:
+        path = paths if isinstance(paths, str) else paths[0]
+        if _classify_path(path) == 'extxyz':
+            return ExtXYZDataset([path], labels, params, chemical_types)
+        else:
+            return DPDataset(path, labels, params, chemical_types)
+    
+    formats = {_classify_path(p) for p in paths}
     if len(formats) > 1:
-        raise ValueError('Mixing DP-directory and extxyz dataset paths is not supported; got both in %s' % (paths,))
+        raise ValueError('Mixing DP and extxyz paths is not supported: %s' % (paths,))
+    
     if formats == {'extxyz'}:
         return ExtXYZDataset(paths, labels, params, chemical_types)
-    return DPDataset(paths, labels, params, chemical_types)
+    else:
+        leaves = [DPDataset(p, labels, params, chemical_types) for p in paths]
+        return DatasetGroup(leaves, chemical_types)
 
 
 class DatasetLeaf:
@@ -239,8 +237,8 @@ class DPDataset(DatasetLeaf):
 
     Parameters
     ----------
-    paths : list of str
-        Paths to DP directories. Each should contain 'type.raw' and 'set.*/' subdirs
+    path : str
+        Path to DP directory. Should contain 'type.raw' and 'set.*/' subdirs
         with .npy files (e.g., coord.npy, energy.npy).
     labels : list of str
         Data labels to load.
@@ -254,17 +252,14 @@ class DPDataset(DatasetLeaf):
     Directory structure: path/type.raw, path/set.000/, path/set.001/, etc.
     Each set.*/ contains label.npy files. Data is concatenated over all sets/paths.
     """
-    def __init__(self, paths, labels, params=None, chemical_types=None):
+    def __init__(self, path, labels, params=None, chemical_types=None):
         self.chemical_types = tuple(chemical_types) if chemical_types else None
-        type_arr = np.genfromtxt(paths[0] + '/type.raw').astype(int)
+        type_arr = np.genfromtxt(path + '/type.raw').astype(int)
         data = {
-            l: np.concatenate(sum(
-                [[np.load(set + l + '.npy') for set in sorted(glob(path + '/set.*/'))]
-                 for path in paths], []))
+            l: np.concatenate([np.load(s + l + '.npy') for s in sorted(glob(path + '/set.*/'))])
             for l in labels
         }
-        super().__init__(labels, params or {}, type_arr, data, paths=paths)
-
+        super().__init__(labels, params or {}, type_arr, data, paths=[path])
 
 class DatasetGroup:
     """

--- a/deepmd_jax/data.py
+++ b/deepmd_jax/data.py
@@ -6,8 +6,10 @@ from os.path import abspath
 from ase.io import read
 from .utils import shift, get_relative_coord, sr
 
+
 def _classify_path(p):
     return 'extxyz' if isinstance(p, str) and p.lower().endswith(('.xyz', '.extxyz')) else 'dp'
+
 
 def _flatten_paths(paths):
     for p in paths:
@@ -16,51 +18,24 @@ def _flatten_paths(paths):
         else:
             yield p
 
-class Dataset():
-    def __init__(self, paths, labels, params={}, chemical_types=None, _in_memory=None):
-        '''
-            A dataset container supporting DP directory format and extxyz files.
 
-            paths:
-                - list of DP data directories (leaf) or list-of-lists (non-leaf); or
-                - list of extxyz file paths (dispatches to from_extxyz); or
-                - unused when _in_memory is provided.
-            labels: data fields to load (e.g., ['coord','box','force','energy']).
-            params: may contain 'atomic_sel' for atomic-label models.
-            chemical_types: optional tuple of atomic numbers (Z) mapping type index -> Z.
-                            Required/produced for extxyz; optional for DP format.
-            _in_memory: internal — dict {'type': np.ndarray, 'data': dict} for leaves
-                        constructed from in-memory data (used by from_extxyz).
-        '''
-        self.chemical_types = tuple(chemical_types) if chemical_types else None
+def Dataset(paths, labels, params=None, chemical_types=None, _in_memory=None):
+    if _in_memory is not None:
+        return DatasetLeaf(labels, params or {}, _in_memory['type'], _in_memory['data'])
+    if isinstance(paths[0], list):
+        subsets = [Dataset(path, labels, params, chemical_types) for path in paths]
+        return DatasetGroup(subsets, chemical_types)
+    formats = {_classify_path(p) for p in _flatten_paths(paths)}
+    if len(formats) > 1:
+        raise ValueError('Mixing DP-directory and extxyz dataset paths is not supported; got both in %s' % (paths,))
+    if formats == {'extxyz'}:
+        return ExtXYZDataset(paths, labels, params, chemical_types)
+    return DPDataset(paths, labels, params, chemical_types)
 
-        if _in_memory is not None:
-            self.is_leaf = True
-            self._finalize_leaf(_in_memory['type'], _in_memory['data'], labels, params, paths=None)
-            return
 
-        formats = {_classify_path(p) for p in _flatten_paths(paths)}
-        if len(formats) > 1:
-            raise ValueError('Mixing DP-directory and extxyz dataset paths is not supported; got both in %s' % (paths,))
-
-        if type(paths[0]) == list:
-            self.is_leaf = False
-            self.subsets = [Dataset(path, labels, params, chemical_types=chemical_types)
-                            for path in paths]
-            self._finalize_non_leaf()
-            return
-
-        if formats == {'extxyz'}:
-            self._init_from_extxyz(paths, labels, params)
-            return
-
-        self.is_leaf = True
-        type_arr = np.genfromtxt(paths[0] + '/type.raw').astype(int)
-        data = {l: np.concatenate(sum([[np.load(set+l+'.npy') for set in sorted(glob(path+'/set.*/'))]
-                                       for path in paths], [])) for l in labels}
-        self._finalize_leaf(type_arr, data, labels, params, paths=paths)
-
-    def _finalize_leaf(self, type_arr, data, labels, params, paths=None):
+class DatasetLeaf:
+    def __init__(self, labels, params, type_arr, data, paths=None):
+        self.chemical_types = getattr(self, 'chemical_types', None)
         self.type = np.array(type_arr, dtype=int)
         self.data = data
         self.natoms = len(self.type)
@@ -69,9 +44,10 @@ class Dataset():
             assert self.data[l].shape[0] == self.nframes, \
                 f"{l}.npy has {self.data[l].shape[0]} frames, expected {self.nframes}"
         self.pointer = self.nframes
-        self.type_count = np.array([(self.type == i).sum() for i in range(max(self.type)+1)])
+        self.type_count = np.array([(self.type == i).sum() for i in range(max(self.type) + 1)])
         self.ntypes = len(self.type_count)
         self.valid_types = np.arange(self.ntypes)
+        self.chemical_types = getattr(self, 'chemical_types', None)
         self.nsel = params.get('atomic_sel', None)
         if self.nsel is not None:
             self.nsel = [i for i in self.nsel if i in range(self.ntypes)]
@@ -89,7 +65,7 @@ class Dataset():
                 try:
                     self.data[l] = self.data[l].reshape(self.data[l].shape[0], self.nlabels, -1)
                     assert self.data[l].shape[2] in (3, 9)
-                except:
+                except Exception:
                     raise ValueError('Atomic label must have 3 (vector) or 9 (3x3 tensor) components per atom.')
                 sel_type = self.type[np.in1d(self.type, self.nsel)]
                 self.data[l] = self.data[l][:, sel_type.argsort(kind='stable')]
@@ -100,7 +76,92 @@ class Dataset():
             print('# Dataset loaded: %d frames/%d atoms. Path:' % (self.nframes, self.natoms),
                   ''.join(['\n# \t\'%s\'' % abspath(path) for path in paths]))
 
-    def _finalize_non_leaf(self):
+    def count_max(self):
+        return np.array(self.type_count)
+
+    def fill_type(self, ntypes):
+        self.type_count = np.pad(self.type_count, (0, ntypes - self.ntypes))
+
+    def _get_stats(self, rcut, bs):
+        if not hasattr(self, 'lattice_args'):
+            raise AttributeError("lattice_args not set. Call compute_lattice_candidate(rcut) before get_stats.")
+        batch = self.get_batch(bs)[0]
+        coord, box = batch['coord'], batch['box']
+        r_Bnm = vmap(get_relative_coord, (0, 0, None, None))(coord, box, self.type_count, self.lattice_args)[1]
+        sr_BnM = [sr(jnp.concatenate(r, axis=-1), rcut) for r in r_Bnm]
+        sr_sum = np.array([sr.sum() for sr in sr_BnM])
+        sr_sum2 = np.array([(sr**2).sum() for sr in sr_BnM])
+        sr_count = np.array([(sr > 1e-15).sum() for sr in sr_BnM])
+        Nnbrs = (np.concatenate(sr_BnM, axis=1) > 0).sum(2).mean() + 1
+        return np.array([sr_sum, sr_sum2, sr_count, Nnbrs * np.ones_like(sr_sum)])
+
+    def get_stats(self, rcut, bs):
+        self.params = {'ntypes': self.ntypes, 'rcut': rcut}
+        sr_sum, sr_sum2, sr_count, Nnbrs = self._get_stats(rcut, bs)
+        sr_sum, sr_sum2, sr_count = sr_sum[self.valid_types], sr_sum2[self.valid_types], sr_count[self.valid_types]
+        self.params['valid_types'] = self.valid_types
+        self.params['sr_mean'] = sr_sum / sr_count
+        self.params['sr_std'] = np.sqrt(sr_sum2 / sr_count - self.params['sr_mean']**2)
+        self.params['Nnbrs'] = Nnbrs[0]
+        if self.chemical_types is not None:
+            self.params['chemical_types'] = self.chemical_types
+        return self.params
+
+    def get_batch(self, batch_size, type='frame'):
+        if type == 'label':
+            batch_size = int(batch_size / self.nlabels + 1)
+        if self.pointer + batch_size > self.nframes:
+            self.pointer = 0
+            perm = np.random.permutation(self.nframes)
+            self.data = {l: self.data[l][perm] for l in self.data}
+        batch = {
+            'atomic' if 'atomic' in l else l:
+            self.data[l][self.pointer:min(self.pointer + batch_size, self.nframes)]
+            for l in self.data
+        }
+        self.pointer += batch_size
+        return batch, tuple(self.type_count), self.lattice_args
+
+    def compute_lattice_candidate(self, rcut):
+        self.lattice_args = compute_lattice_candidate(self.data['box'], rcut)
+
+    def fit_energy(self):
+        energy_stats = self._get_energy_stats()
+        type_count, energy_mean = [np.array(x) for x in zip(*energy_stats)]
+        type_count = type_count[:, self.valid_types]
+        return np.linalg.lstsq(type_count, energy_mean, rcond=1e-3)[0].astype(np.float32)
+
+    def get_atomic_label_scale(self):
+        label = [label for label in self.data.keys() if 'atomic' in label][0]
+        return np.std(self.data[label])
+
+    def _get_energy_stats(self):
+        return [(self.type_count, self.data['energy'].mean())]
+
+    def get_flattened_data(self):
+        return [{'data': self.data, 'type_count': self.type_count, 'lattice_args': self.lattice_args}]
+
+    def get_leaves(self):
+        return [self]
+
+
+class DPDataset(DatasetLeaf):
+    def __init__(self, paths, labels, params=None, chemical_types=None):
+        self.chemical_types = tuple(chemical_types) if chemical_types else None
+        type_arr = np.genfromtxt(paths[0] + '/type.raw').astype(int)
+        data = {
+            l: np.concatenate(sum(
+                [[np.load(set + l + '.npy') for set in sorted(glob(path + '/set.*/'))]
+                 for path in paths], []))
+            for l in labels
+        }
+        super().__init__(labels, params or {}, type_arr, data, paths=paths)
+
+
+class DatasetGroup:
+    def __init__(self, subsets, chemical_types=None):
+        self.subsets = subsets
+        self.chemical_types = tuple(chemical_types) if chemical_types else None
         self.nframes = sum([subset.nframes for subset in self.subsets])
         self.ntypes = max([subset.ntypes for subset in self.subsets])
         [subset.fill_type(self.ntypes) for subset in self.subsets]
@@ -114,11 +175,58 @@ class Dataset():
             if cts:
                 self.chemical_types = cts.pop()
 
-    def _init_from_extxyz(self, paths, labels, params):
-        '''
-            Parse extxyz files, build global Z->type map (or use supplied chemical_types),
-            group frames by type_count, and construct in-memory leaf subsets under a non-leaf parent.
-        '''
+    def count_max(self):
+        return np.array([subset.count_max() for subset in self.subsets]).max(0)
+
+    def fill_type(self, ntypes):
+        for subset in self.subsets:
+            subset.fill_type(ntypes)
+
+    def _get_stats(self, rcut, bs):
+        s = np.stack([subset._get_stats(rcut, bs) for subset in self.subsets], axis=-1)
+        return (s * self.prob).sum(-1)
+
+    def get_stats(self, rcut, bs):
+        self.params = {'ntypes': self.ntypes, 'rcut': rcut}
+        sr_sum, sr_sum2, sr_count, Nnbrs = self._get_stats(rcut, bs)
+        sr_sum, sr_sum2, sr_count = sr_sum[self.valid_types], sr_sum2[self.valid_types], sr_count[self.valid_types]
+        self.params['valid_types'] = self.valid_types
+        self.params['sr_mean'] = sr_sum / sr_count
+        self.params['sr_std'] = np.sqrt(sr_sum2 / sr_count - self.params['sr_mean']**2)
+        self.params['Nnbrs'] = Nnbrs[0]
+        if self.chemical_types is not None:
+            self.params['chemical_types'] = self.chemical_types
+        return self.params
+
+    def get_batch(self, batch_size, type='frame'):
+        subset = np.random.choice(len(self.subsets), p=self.prob)
+        return self.subsets[subset].get_batch(batch_size, type)
+
+    def compute_lattice_candidate(self, rcut):
+        for subset in self.subsets:
+            subset.compute_lattice_candidate(rcut)
+
+    def fit_energy(self):
+        energy_stats = self._get_energy_stats()
+        type_count, energy_mean = [np.array(x) for x in zip(*energy_stats)]
+        type_count = type_count[:, self.valid_types]
+        return np.linalg.lstsq(type_count, energy_mean, rcond=1e-3)[0].astype(np.float32)
+
+    def get_atomic_label_scale(self):
+        return (np.array([subset.get_atomic_label_scale() for subset in self.subsets]) * np.array(self.prob)).sum()
+
+    def _get_energy_stats(self):
+        return sum([subset._get_energy_stats() for subset in self.subsets], [])
+
+    def get_flattened_data(self):
+        return sum([subset.get_flattened_data() for subset in self.subsets], [])
+
+    def get_leaves(self):
+        return sum([s.get_leaves() for s in self.subsets], [])
+
+
+class ExtXYZDataset(DatasetGroup):
+    def __init__(self, paths, labels, params=None, chemical_types=None):
         raw_frames = []
         all_zs = set()
         for path in paths:
@@ -147,10 +255,9 @@ class Dataset():
                             raise ValueError('Label %s not found in extxyz frame from %s' % (l, path))
                 raw_frames.append(entry)
 
-        if self.chemical_types is None:
+        if chemical_types is None:
             chemical_types = tuple(sorted(all_zs))
         else:
-            chemical_types = self.chemical_types
             unknown = all_zs - set(chemical_types)
             if unknown:
                 raise ValueError(
@@ -164,139 +271,34 @@ class Dataset():
         for entry in raw_frames:
             zs = entry.pop('_zs')
             types = np.array([z_to_idx[int(z)] for z in zs], dtype=int)
-            natoms = len(types)
-            perm = types.argsort(kind='stable')
-            types_sorted = types[perm]
-            permuted = {}
-            for k, v in entry.items():
-                if isinstance(v, np.ndarray) and v.ndim > 0 and v.shape[0] == natoms:
-                    permuted[k] = v[perm]
-                else:
-                    permuted[k] = v
-            tc = tuple(int((types_sorted == i).sum()) for i in range(ntypes))
-            grp = groups.setdefault(tc, {'type': types_sorted, 'frames': []})
-            grp['frames'].append(permuted)
+            tc = tuple(int((np.sort(types) == i).sum()) for i in range(ntypes))
+            grp = groups.setdefault(tc, {'type': types, 'frames': []})
+            grp['frames'].append(entry)
 
         subsets = []
-        for tc, grp in groups.items():
+        for grp in groups.values():
             frames = grp['frames']
             data = {l: np.stack([f[l] for f in frames]) for l in labels}
-            leaf = Dataset(
-                paths=None, labels=labels, params=params,
-                chemical_types=chemical_types,
-                _in_memory={'type': grp['type'], 'data': data},
-            )
-            subsets.append(leaf)
+            subsets.append(DatasetLeaf(labels, params or {}, grp['type'], data))
 
-        self.is_leaf = False
-        self.subsets = subsets
-        self._finalize_non_leaf()
+        super().__init__(subsets, chemical_types=chemical_types)
         print('# Dataset loaded (extxyz): %d frames in %d composition group(s). Path:'
               % (len(raw_frames), len(subsets)),
               ''.join(['\n# \t\'%s\'' % abspath(p) for p in paths]))
 
-    def count_max(self):
-        if self.is_leaf:
-            return np.array(self.type_count)
-        else:
-            return np.array([subset.count_max() for subset in self.subsets]).max(0)
 
-    def fill_type(self, ntypes):
-        if not self.is_leaf:
-            [subset.fill_type(ntypes) for subset in self.subsets]
-        else:
-            self.type_count = np.pad(self.type_count, (0,ntypes-self.ntypes))
-
-    def _get_stats(self, rcut, bs):
-        if self.is_leaf:
-            batch = self.get_batch(bs)[0]
-            coord, box = batch['coord'], batch['box']
-            r_Bnm = vmap(get_relative_coord,(0,0,None,None))(coord, box, self.type_count, self.lattice_args)[1]
-            sr_BnM = [sr(jnp.concatenate(r,axis=-1), rcut) for r in r_Bnm]
-            sr_sum = np.array([sr.sum() for sr in sr_BnM])
-            sr_sum2 = np.array([(sr**2).sum() for sr in sr_BnM])
-            sr_count = np.array([(sr>1e-15).sum() for sr in sr_BnM])
-            Nnbrs = (np.concatenate(sr_BnM, axis=1) > 0).sum(2).mean() + 1
-            return np.array([sr_sum, sr_sum2, sr_count, Nnbrs*np.ones_like(sr_sum)]) # (4, ntypes)
-        else:
-            s = np.stack([subset._get_stats(rcut, bs) for subset in self.subsets], axis=-1)
-            return (s * self.prob).sum(-1)
-
-    def get_stats(self, rcut, bs):
-        self.params = {'ntypes': self.ntypes, 'rcut': rcut}
-        sr_sum, sr_sum2, sr_count, Nnbrs = self._get_stats(rcut, bs)
-        sr_sum, sr_sum2, sr_count = sr_sum[self.valid_types], sr_sum2[self.valid_types], sr_count[self.valid_types]
-        self.params['valid_types'] = self.valid_types
-        self.params['sr_mean'] = sr_sum / sr_count
-        self.params['sr_std'] = np.sqrt(sr_sum2 / sr_count - self.params['sr_mean']**2)
-        self.params['Nnbrs'] = Nnbrs[0]
-        if self.chemical_types is not None:
-            self.params['chemical_types'] = self.chemical_types
-        return self.params
-
-    def get_batch(self, batch_size, type='frame'):
-        if not self.is_leaf:
-            subset = np.random.choice(len(self.subsets), p=self.prob)
-            return self.subsets[subset].get_batch(batch_size, type)
-        else:
-            if type == 'label':
-                batch_size = int(batch_size / self.nlabels + 1)
-            if self.pointer + batch_size > self.nframes:
-                self.pointer = 0
-                perm = np.random.permutation(self.nframes)
-                self.data = {l: self.data[l][perm] for l in self.data}
-            batch = {'atomic' if 'atomic' in l else l:
-                     self.data[l][self.pointer:min(self.pointer+batch_size,self.nframes)] for l in self.data}
-            self.pointer += batch_size
-            return batch, tuple(self.type_count), self.lattice_args
-
-    def compute_lattice_candidate(self, rcut): # computes candidate lattice vectors within rcut for neighbor images
-        if not self.is_leaf:
-            for subset in self.subsets:
-                subset.compute_lattice_candidate(rcut)
-        else:
-            self.lattice_args = compute_lattice_candidate(self.data['box'], rcut)
-
-    def fit_energy(self):
-        energy_stats = self._get_energy_stats()
-        type_count, energy_mean = [np.array(x) for x in zip(*energy_stats)]
-        type_count = type_count[:,self.valid_types]
-        return np.linalg.lstsq(type_count, energy_mean, rcond=1e-3)[0].astype(np.float32)
-
-    def get_atomic_label_scale(self):
-        if not self.is_leaf:
-            return (np.array([subset.get_atomic_label_scale() for subset in self.subsets]) * np.array(self.prob)).sum()
-        else:
-            label = [label for label in self.data.keys() if 'atomic' in label][0]
-            return np.std(self.data[label])
-
-    def _get_energy_stats(self):
-        if self.is_leaf:
-            return [(self.type_count, self.data['energy'].mean())]
-        else:
-            return sum([subset._get_energy_stats() for subset in self.subsets], [])
-
-    def get_flattened_data(self):
-        if self.is_leaf:
-            return [{'data':self.data, 'type_count':self.type_count, 'lattice_args':self.lattice_args}]
-        else:
-            return sum([subset.get_flattened_data() for subset in self.subsets], [])
-
-    def get_leaves(self):
-        if self.is_leaf:
-            return [self]
-        return sum([s.get_leaves() for s in self.subsets], [])
-
-
-def compute_lattice_candidate(boxes, rcut, print_info=True, disable_ortho=False): # boxes (nframes,3,3)
+def compute_lattice_candidate(boxes, rcut, print_info=True, disable_ortho=False):
     N = 2  # This algorithm is heuristic and subject to change. Increase N in case of missing neighbors.
     ortho = not vmap(lambda box: box - jnp.diag(jnp.diag(box)))(boxes).any()
-    recp_norm = jnp.linalg.norm((jnp.linalg.inv(boxes)), axis=-1)    # (nframes,3)
-    n = np.ceil(rcut * recp_norm - 0.5).astype(int).max(0)           # (3,)
-    lattice_cand = jnp.stack(np.meshgrid(range(-n[0],n[0]+1),range(-n[1],n[1]+1),range(-n[2],n[2]+1),indexing='ij'),axis=-1).reshape(-1,3)
-    trial_points = jnp.stack(np.meshgrid(np.arange(-N,N+1),np.arange(-N,N+1),np.arange(-N,N+1)),axis=-1).reshape(-1,3) / (2*N)
-    is_neighbor = jnp.linalg.norm((lattice_cand[:,None]-trial_points)[None] @ boxes[:,None], axis=-1) < rcut  # (nframes,l,t)
-    lattice_cand = np.array(lattice_cand[is_neighbor.any((0,2))])
+    recp_norm = jnp.linalg.norm((jnp.linalg.inv(boxes)), axis=-1)
+    n = np.ceil(rcut * recp_norm - 0.5).astype(int).max(0)
+    lattice_cand = jnp.stack(
+        np.meshgrid(range(-n[0], n[0] + 1), range(-n[1], n[1] + 1), range(-n[2], n[2] + 1), indexing='ij'),
+        axis=-1).reshape(-1, 3)
+    trial_points = jnp.stack(np.meshgrid(np.arange(-N, N + 1), np.arange(-N, N + 1), np.arange(-N, N + 1)),
+                             axis=-1).reshape(-1, 3) / (2 * N)
+    is_neighbor = jnp.linalg.norm((lattice_cand[:, None] - trial_points)[None] @ boxes[:, None], axis=-1) < rcut
+    lattice_cand = np.array(lattice_cand[is_neighbor.any((0, 2))])
     lattice_max = is_neighbor.sum(1).max().item()
     if print_info:
         print('# Lattice vectors for neighbor images: Max %d out of %d candidates.' % (lattice_max, len(lattice_cand)))

--- a/deepmd_jax/data.py
+++ b/deepmd_jax/data.py
@@ -6,57 +6,181 @@ from os.path import abspath
 from ase.io import read
 from .utils import shift, get_relative_coord, sr
 
-class DPDataset():
-    def __init__(self, paths, labels, params={}):
+class Dataset():
+    def __init__(self, paths, labels, params={}, chemical_types=None, _in_memory=None):
+        '''
+            A dataset container supporting DP directory format and extxyz files.
+
+            paths:
+                - list of DP data directories (leaf) or list-of-lists (non-leaf); or
+                - list of extxyz file paths (dispatches to from_extxyz); or
+                - unused when _in_memory is provided.
+            labels: data fields to load (e.g., ['coord','box','force','energy']).
+            params: may contain 'atomic_sel' for atomic-label models.
+            chemical_types: optional tuple of atomic numbers (Z) mapping type index -> Z.
+                            Required/produced for extxyz; optional for DP format.
+            _in_memory: internal — dict {'type': np.ndarray, 'data': dict} for leaves
+                        constructed from in-memory data (used by from_extxyz).
+        '''
+        self.chemical_types = tuple(chemical_types) if chemical_types else None
+
+        if _in_memory is not None:
+            self.is_leaf = True
+            self._finalize_leaf(_in_memory['type'], _in_memory['data'], labels, params, paths=None)
+            return
+
         if type(paths[0]) == list:
             self.is_leaf = False
-            self.subsets = [DPDataset(path, labels, params) for path in paths]
-            self.nframes = sum([subset.nframes for subset in self.subsets])
-            self.ntypes = max([subset.ntypes for subset in self.subsets])
-            [subset.fill_type(self.ntypes) for subset in self.subsets]
-            self.prob = np.array([subset.nframes for subset in self.subsets]) / self.nframes
-            self.type_count = self.count_max()
-            self.valid_types = np.arange(self.ntypes)[self.type_count > 0]
+            self.subsets = [Dataset(path, labels, params, chemical_types=chemical_types)
+                            for path in paths]
+            self._finalize_non_leaf()
+            return
+
+        if isinstance(paths[0], str) and paths[0].lower().endswith(('.xyz', '.extxyz')):
+            self._init_from_extxyz(paths, labels, params)
+            return
+
+        self.is_leaf = True
+        type_arr = np.genfromtxt(paths[0] + '/type.raw').astype(int)
+        data = {l: np.concatenate(sum([[np.load(set+l+'.npy') for set in sorted(glob(path+'/set.*/'))]
+                                       for path in paths], [])) for l in labels}
+        self._finalize_leaf(type_arr, data, labels, params, paths=paths)
+
+    def _finalize_leaf(self, type_arr, data, labels, params, paths=None):
+        self.type = np.array(type_arr, dtype=int)
+        self.data = data
+        self.natoms = len(self.type)
+        self.nframes = len(self.data['coord'])
+        for l in labels:
+            assert self.data[l].shape[0] == self.nframes, \
+                f"{l}.npy has {self.data[l].shape[0]} frames, expected {self.nframes}"
+        self.pointer = self.nframes
+        self.type_count = np.array([(self.type == i).sum() for i in range(max(self.type)+1)])
+        self.ntypes = len(self.type_count)
+        self.valid_types = np.arange(self.ntypes)
+        self.nsel = params.get('atomic_sel', None)
+        if self.nsel is not None:
+            self.nsel = [i for i in self.nsel if i in range(self.ntypes)]
+        if any(['atomic' in l for l in labels]):
+            self.nlabels = sum(self.type_count[self.nsel])
         else:
-            self.is_leaf = True
-            self.type = np.genfromtxt(paths[0] + '/type.raw').astype(int)
-            self.data = {l: np.concatenate(sum([[np.load(set+l+'.npy') for set in sorted(glob(path+'/set.*/'))]
-                                                for path in paths], [])) for l in labels}
-            self.natoms = len(self.type)
-            self.nframes = len(self.data['coord'])
-            for l in labels:
-                assert self.data[l].shape[0] == self.nframes, \
-                    f"{l}.npy has {self.data[l].shape[0]} frames, expected {self.nframes}"
-            self.pointer = self.nframes
-            self.type_count = np.array([(self.type == i).sum() for i in range(max(self.type)+1)])
-            self.ntypes = len(self.type_count)
-            self.valid_types = np.arange(self.ntypes)
-            self.nsel = params.get('atomic_sel', None)
-            if self.nsel is not None:
-                self.nsel = [i for i in self.nsel if i in range(self.ntypes)]
-            if any(['atomic' in l for l in labels]):
-                self.nlabels = sum(self.type_count[self.nsel])
-            else:
-                self.nlabels = self.natoms
-            for l in labels:
-                if l in ['coord', 'force']:
-                    self.data[l] = self.data[l].reshape(self.data[l].shape[0],-1,3)
-                    self.data[l] = self.data[l][:,self.type.argsort(kind='stable')]
-                if l == 'energy':
-                    self.data[l] = self.data[l].reshape(-1)
-                if 'atomic' in l:
-                    try:
-                        self.data[l] = self.data[l].reshape(self.data[l].shape[0],self.nlabels,-1)
-                        assert self.data[l].shape[2] in (3, 9)
-                    except:
-                        raise ValueError('Atomic label must have 3 (vector) or 9 (3x3 tensor) components per atom.')
-                    sel_type = self.type[np.in1d(self.type, self.nsel)]
-                    self.data[l] = self.data[l][:,sel_type.argsort(kind='stable')]
-            self.data['box'] = self.data['box'].reshape(-1,3,3)
-            self.data['coord'] = np.array(vmap(shift)(self.data['coord'], self.data['box']))
-            print('# Dataset loaded: %d frames/%d atoms. Path:'%(self.nframes,self.natoms),
+            self.nlabels = self.natoms
+        perm = self.type.argsort(kind='stable')
+        for l in labels:
+            if l in ['coord', 'force']:
+                self.data[l] = self.data[l].reshape(self.data[l].shape[0], -1, 3)[:, perm]
+            if l == 'energy':
+                self.data[l] = self.data[l].reshape(-1)
+            if 'atomic' in l:
+                try:
+                    self.data[l] = self.data[l].reshape(self.data[l].shape[0], self.nlabels, -1)
+                    assert self.data[l].shape[2] in (3, 9)
+                except:
+                    raise ValueError('Atomic label must have 3 (vector) or 9 (3x3 tensor) components per atom.')
+                sel_type = self.type[np.in1d(self.type, self.nsel)]
+                self.data[l] = self.data[l][:, sel_type.argsort(kind='stable')]
+        self.data['box'] = self.data['box'].reshape(-1, 3, 3)
+        self.data['coord'] = np.array(vmap(shift)(self.data['coord'], self.data['box']))
+        self.type = self.type[perm]
+        if paths is not None:
+            print('# Dataset loaded: %d frames/%d atoms. Path:' % (self.nframes, self.natoms),
                   ''.join(['\n# \t\'%s\'' % abspath(path) for path in paths]))
-            
+
+    def _finalize_non_leaf(self):
+        self.nframes = sum([subset.nframes for subset in self.subsets])
+        self.ntypes = max([subset.ntypes for subset in self.subsets])
+        [subset.fill_type(self.ntypes) for subset in self.subsets]
+        self.prob = np.array([subset.nframes for subset in self.subsets]) / self.nframes
+        self.type_count = self.count_max()
+        self.valid_types = np.arange(self.ntypes)[self.type_count > 0]
+        if self.chemical_types is None:
+            cts = {s.chemical_types for s in self.subsets if s.chemical_types is not None}
+            if len(cts) > 1:
+                raise ValueError('Inconsistent chemical_types across subsets: %s' % cts)
+            if cts:
+                self.chemical_types = cts.pop()
+
+    def _init_from_extxyz(self, paths, labels, params):
+        '''
+            Parse extxyz files, build global Z->type map (or use supplied chemical_types),
+            group frames by type_count, and construct in-memory leaf subsets under a non-leaf parent.
+        '''
+        raw_frames = []
+        all_zs = set()
+        for path in paths:
+            atoms_list = read(path, index=':')
+            if not isinstance(atoms_list, list):
+                atoms_list = [atoms_list]
+            for atoms in atoms_list:
+                zs = np.asarray(atoms.get_atomic_numbers(), dtype=int)
+                all_zs.update(zs.tolist())
+                entry = {'_zs': zs}
+                for l in labels:
+                    if l == 'box':
+                        entry['box'] = np.asarray(atoms.get_cell().array, dtype=np.float32)
+                    elif l == 'coord':
+                        entry['coord'] = np.asarray(atoms.get_positions(), dtype=np.float32)
+                    elif l == 'force':
+                        entry['force'] = np.asarray(atoms.get_forces(), dtype=np.float32)
+                    elif l == 'energy':
+                        entry['energy'] = np.asarray(atoms.get_potential_energy(), dtype=np.float32)
+                    else:
+                        if l in atoms.arrays:
+                            entry[l] = np.asarray(atoms.arrays[l], dtype=np.float32)
+                        elif l in atoms.info:
+                            entry[l] = np.asarray(atoms.info[l], dtype=np.float32)
+                        else:
+                            raise ValueError('Label %s not found in extxyz frame from %s' % (l, path))
+                raw_frames.append(entry)
+
+        if self.chemical_types is None:
+            chemical_types = tuple(sorted(all_zs))
+        else:
+            chemical_types = self.chemical_types
+            unknown = all_zs - set(chemical_types)
+            if unknown:
+                raise ValueError(
+                    'Atomic numbers %s in extxyz files not in chemical_types=%s'
+                    % (sorted(unknown), chemical_types))
+        self.chemical_types = chemical_types
+        z_to_idx = {z: i for i, z in enumerate(chemical_types)}
+        ntypes = len(chemical_types)
+
+        groups = {}
+        for entry in raw_frames:
+            zs = entry.pop('_zs')
+            types = np.array([z_to_idx[int(z)] for z in zs], dtype=int)
+            natoms = len(types)
+            perm = types.argsort(kind='stable')
+            types_sorted = types[perm]
+            permuted = {}
+            for k, v in entry.items():
+                if isinstance(v, np.ndarray) and v.ndim > 0 and v.shape[0] == natoms:
+                    permuted[k] = v[perm]
+                else:
+                    permuted[k] = v
+            tc = tuple(int((types_sorted == i).sum()) for i in range(ntypes))
+            grp = groups.setdefault(tc, {'type': types_sorted, 'frames': []})
+            grp['frames'].append(permuted)
+
+        subsets = []
+        for tc, grp in groups.items():
+            frames = grp['frames']
+            data = {l: np.stack([f[l] for f in frames]) for l in labels}
+            leaf = Dataset(
+                paths=None, labels=labels, params=params,
+                chemical_types=chemical_types,
+                _in_memory={'type': grp['type'], 'data': data},
+            )
+            subsets.append(leaf)
+
+        self.is_leaf = False
+        self.subsets = subsets
+        self._finalize_non_leaf()
+        print('# Dataset loaded (extxyz): %d frames in %d composition group(s). Path:'
+              % (len(raw_frames), len(subsets)),
+              ''.join(['\n# \t\'%s\'' % abspath(p) for p in paths]))
+
     def count_max(self):
         if self.is_leaf:
             return np.array(self.type_count)
@@ -83,7 +207,7 @@ class DPDataset():
         else:
             s = np.stack([subset._get_stats(rcut, bs) for subset in self.subsets], axis=-1)
             return (s * self.prob).sum(-1)
-        
+
     def get_stats(self, rcut, bs):
         self.params = {'ntypes': self.ntypes, 'rcut': rcut}
         sr_sum, sr_sum2, sr_count, Nnbrs = self._get_stats(rcut, bs)
@@ -92,6 +216,8 @@ class DPDataset():
         self.params['sr_mean'] = sr_sum / sr_count
         self.params['sr_std'] = np.sqrt(sr_sum2 / sr_count - self.params['sr_mean']**2)
         self.params['Nnbrs'] = Nnbrs[0]
+        if self.chemical_types is not None:
+            self.params['chemical_types'] = self.chemical_types
         return self.params
 
     def get_batch(self, batch_size, type='frame'):
@@ -116,13 +242,13 @@ class DPDataset():
                 subset.compute_lattice_candidate(rcut)
         else:
             self.lattice_args = compute_lattice_candidate(self.data['box'], rcut)
-    
+
     def fit_energy(self):
         energy_stats = self._get_energy_stats()
         type_count, energy_mean = [np.array(x) for x in zip(*energy_stats)]
         type_count = type_count[:,self.valid_types]
         return np.linalg.lstsq(type_count, energy_mean, rcond=1e-3)[0].astype(np.float32)
-    
+
     def get_atomic_label_scale(self):
         if not self.is_leaf:
             return (np.array([subset.get_atomic_label_scale() for subset in self.subsets]) * np.array(self.prob)).sum()
@@ -135,199 +261,17 @@ class DPDataset():
             return [(self.type_count, self.data['energy'].mean())]
         else:
             return sum([subset._get_energy_stats() for subset in self.subsets], [])
-        
+
     def get_flattened_data(self):
         if self.is_leaf:
             return [{'data':self.data, 'type_count':self.type_count, 'lattice_args':self.lattice_args}]
         else:
             return sum([subset.get_flattened_data() for subset in self.subsets], [])
 
-class EXTXYZDataset():
-    def __init__(self, paths, labels, params={}):
-        if type(paths[0]) == list:
-            self.is_leaf = False
-            self.subsets = [EXTXYZDataset(path, labels, params) for path in paths]
-            self.nframes = sum([subset.nframes for subset in self.subsets])
-            self.ntypes = max([subset.ntypes for subset in self.subsets])
-            [subset.fill_type(self.ntypes) for subset in self.subsets]
-            self.prob = np.array([subset.nframes for subset in self.subsets]) / self.nframes
-            self.type_count = self.count_max()
-            self.valid_types = np.arange(self.ntypes)[self.type_count > 0]
-        else:
-            self.is_leaf = True
-            self.labels = labels
-            self.params = params
-            self.frames = []
-            self.paths = paths
-            for path in paths:
-                atoms_list = read(path, index=':')
-                if not isinstance(atoms_list, list):
-                    atoms_list = [atoms_list]
-                for atoms in atoms_list:
-                    frame = {}
-                    try:
-                        frame['atomic_numbers'] = np.asarray(atoms.get_atomic_numbers(), dtype=int)
-                    except RuntimeError:
-                        raise ValueError('Extended xyz file missing atomic numbers for frame in %s' % path)
-                    for l in labels:
-                        if l == 'box':
-                            try:
-                                frame['box'] = np.asarray(atoms.get_cell().array, dtype=np.float32)
-                            except RuntimeError:
-                                raise ValueError('Extended xyz file missing box for frame in %s' % path)
-                        elif l == 'coord':
-                            try:
-                                frame['coord'] = np.asarray(atoms.get_positions(), dtype=np.float32)
-                            except RuntimeError:
-                                raise ValueError('Extended xyz file missing coord for frame in %s' % path)
-                        elif l == 'force':
-                            try:
-                                frame['force'] = np.asarray(atoms.get_forces(), dtype=np.float32)
-                            except RuntimeError:
-                                raise ValueError('Extended xyz file missing forces for frame in %s' % path)
-                        elif l == 'energy':
-                            try:
-                                energy = atoms.get_potential_energy()
-                                if energy is None:
-                                    raise ValueError('Extended xyz file missing energy for frame in %s' % path)
-                                frame['energy'] = np.asarray(energy, dtype=np.float32)
-                            except RuntimeError:
-                                raise ValueError('Extended xyz file missing energy for frame in %s' % path)
-                        else:
-                            if l in atoms.arrays:
-                                frame[l] = np.asarray(atoms.arrays[l], dtype=np.float32)
-                            elif l in atoms.info:
-                                frame[l] = np.asarray(atoms.info[l], dtype=np.float32)
-                            else:
-                                raise ValueError('Atomic label %s not found in frame arrays or info for %s' % (l, path))
-                    if 'coord' in frame and 'box' in frame:
-                        frame['coord'] = np.array(shift(frame['coord'], frame['box']))
-                    self.frames.append(frame)
-            # Map atomic numbers to types
-            all_atomic_numbers = set()
-            for frame in self.frames:
-                all_atomic_numbers.update(frame['atomic_numbers'])
-            unique_atomic_numbers = sorted(all_atomic_numbers)
-            self.atomic_to_type = {an: i for i, an in enumerate(unique_atomic_numbers)}
-            self.ntypes = len(unique_atomic_numbers)
-            self.valid_types = np.arange(self.ntypes)
-            for frame in self.frames:
-                frame['type'] = np.array([self.atomic_to_type[an] for an in frame['atomic_numbers']], dtype=int)
-                perm = frame['type'].argsort(kind='stable')
-                natoms = len(frame['type'])
-                # Permute all arrays with atom dimension according to sorted types for consistent ordering
-                for k, v in frame.items():
-                    if isinstance(v, np.ndarray) and v.ndim > 0 and v.shape[0] == natoms:
-                        frame[k] = v[perm]
-            self.nframes = len(self.frames)
-            self.order = np.arange(self.nframes)
-            self.pointer = self.nframes
-            self.natoms = max([frame['coord'].shape[0] for frame in self.frames]) if self.frames else 0
-            print('# EXTXYZ Dataset loaded: %d frames. Path:' % self.nframes,
-                  ''.join(['\n# \t\'%s\'' % abspath(path) for path in paths]))
-
-    def count_max(self):
+    def get_leaves(self):
         if self.is_leaf:
-            type_counts = []
-            for frame in self.frames:
-                tc = np.array([(frame['type'] == i).sum() for i in range(self.ntypes)])
-                type_counts.append(tc)
-            return np.array(type_counts).max(0)
-        else:
-            return np.array([subset.count_max() for subset in self.subsets]).max(0)
-
-    def fill_type(self, ntypes):
-        if not self.is_leaf:
-            [subset.fill_type(ntypes) for subset in self.subsets]
-        else:
-            self.ntypes = ntypes
-            self.valid_types = np.arange(self.ntypes)
-
-    def get_batch(self, batch_size, type='frame'):
-        if not self.is_leaf:
-            subset = np.random.choice(len(self.subsets), p=self.prob)
-            return self.subsets[subset].get_batch(batch_size, type)
-        else:
-            batch_size = 1
-            if self.pointer + batch_size > self.nframes:
-                self.pointer = 0
-                np.random.shuffle(self.order)
-            index = self.order[self.pointer]
-            self.pointer += batch_size
-            batch = {k: v.copy() if isinstance(v, np.ndarray) else v
-                     for k, v in self.frames[index].items()}
-            batch['coord'] = batch['coord'][None]
-            batch['box'] = batch['box'][None]
-            if 'force' in batch:
-                batch['force'] = batch['force'][None]
-            if 'energy' in batch:
-                batch['energy'] = np.array([batch['energy']])
-            for l in list(batch.keys()):
-                if 'atomic' in l:
-                    batch[l] = batch[l][None]
-            # Compute type_count for the single frame based on mapped types
-            types = batch['type']
-            type_count = np.array([(types == i).sum() for i in range(self.ntypes)])
-            return batch, tuple(type_count), self.lattice_args
-
-    def compute_lattice_candidate(self, rcut):
-        if not self.is_leaf:
-            for subset in self.subsets:
-                subset.compute_lattice_candidate(rcut)
-        else:
-            boxes = np.stack([frame['box'] for frame in self.frames])
-            self.lattice_args = compute_lattice_candidate(boxes, rcut)
-
-    def get_flattened_data(self):
-        if self.is_leaf:
-            return [{'data':frame, 'lattice_args':self.lattice_args} for frame in self.frames]
-        else:
-            return sum([subset.get_flattened_data() for subset in self.subsets], [])
-
-    def fit_energy(self):
-        energy_stats = self._get_energy_stats()
-        type_counts, energies = [np.array(x) for x in zip(*energy_stats)]
-        return np.linalg.lstsq(type_counts, energies, rcond=1e-3)[0].astype(np.float32)
-    
-    def get_atomic_label_scale(self):
-        if not self.is_leaf:
-            return (np.array([subset.get_atomic_label_scale() for subset in self.subsets]) * np.array(self.prob)).sum()
-        else:
-            label = [l for l in self.frames[0].keys() if 'atomic' in l][0]
-            all_labels = np.concatenate([frame[label].flatten() for frame in self.frames])
-            return np.std(all_labels)
-
-    def _get_energy_stats(self):
-        if self.is_leaf:
-            return [(np.array([(frame['type'] == i).sum() for i in range(self.ntypes)]), frame['energy']) for frame in self.frames]
-        else:
-            return sum([subset._get_energy_stats() for subset in self.subsets], [])
-
-    def _get_stats(self, rcut, bs):
-        if self.is_leaf:
-            batch, type_count, lattice_args = self.get_batch(bs)
-            coord, box = batch['coord'], batch['box']
-            type_count = np.array(type_count)
-            r_Bnm = vmap(get_relative_coord,(0,0,None,None))(coord, box, type_count, lattice_args)[1]
-            sr_BnM = [sr(jnp.concatenate(r,axis=-1), rcut) for r in r_Bnm]
-            sr_sum = np.array([sr.sum() for sr in sr_BnM])
-            sr_sum2 = np.array([(sr**2).sum() for sr in sr_BnM])
-            sr_count = np.array([(sr>1e-15).sum() for sr in sr_BnM])
-            Nnbrs = (np.concatenate(sr_BnM, axis=1) > 0).sum(2).mean() + 1
-            return np.array([sr_sum, sr_sum2, sr_count, Nnbrs*np.ones_like(sr_sum)]) # (4, ntypes)
-        else:
-            s = np.stack([subset._get_stats(rcut, bs) for subset in self.subsets], axis=-1)
-            return (s * self.prob).sum(-1)
-        
-    def get_stats(self, rcut, bs):
-        self.params = {'ntypes': self.ntypes, 'rcut': rcut}
-        sr_sum, sr_sum2, sr_count, Nnbrs = self._get_stats(rcut, bs)
-        sr_sum, sr_sum2, sr_count = sr_sum[self.valid_types], sr_sum2[self.valid_types], sr_count[self.valid_types]
-        self.params['valid_types'] = self.valid_types
-        self.params['sr_mean'] = sr_sum / sr_count
-        self.params['sr_std'] = np.sqrt(sr_sum2 / sr_count - self.params['sr_mean']**2)
-        self.params['Nnbrs'] = Nnbrs[0]
-        return self.params
+            return [self]
+        return sum([s.get_leaves() for s in self.subsets], [])
 
 
 def compute_lattice_candidate(boxes, rcut, print_info=True, disable_ortho=False): # boxes (nframes,3,3)

--- a/deepmd_jax/data.py
+++ b/deepmd_jax/data.py
@@ -166,18 +166,21 @@ class EXTXYZDataset():
                 for atoms in atoms_list:
                     frame = {}
                     frame['coord'] = np.asarray(atoms.get_positions(), dtype=np.float32)
-                    frame['box'] = np.asarray(atoms.get_cell(), dtype=np.float32)
+                    frame['box'] = np.asarray(atoms.get_cell().array, dtype=np.float32)
                     frame['atomic_numbers'] = np.asarray(atoms.get_atomic_numbers(), dtype=int)
                     if 'force' in labels:
-                        if 'forces' in atoms.arrays:
-                            frame['force'] = np.asarray(atoms.arrays['forces'], dtype=np.float32)
-                        else:
+                        try:
+                            frame['force'] = np.asarray(atoms.get_forces(), dtype=np.float32)
+                        except RuntimeError:
                             raise ValueError('Extended xyz file missing forces for frame in %s' % path)
                     if 'energy' in labels:
-                        energy = atoms.info.get('energy', None)
-                        if energy is None:
+                        try:
+                            energy = atoms.get_potential_energy()
+                            if energy is None:
+                                raise ValueError('Extended xyz file missing energy for frame in %s' % path)
+                            frame['energy'] = np.asarray(energy, dtype=np.float32)
+                        except RuntimeError:
                             raise ValueError('Extended xyz file missing energy for frame in %s' % path)
-                        frame['energy'] = np.asarray(energy, dtype=np.float32)
                     for l in labels:
                         if 'atomic' in l and l not in frame:
                             if l in atoms.arrays:
@@ -235,6 +238,15 @@ class EXTXYZDataset():
             index = self.order[self.pointer]
             self.pointer += batch_size
             batch = self.frames[index]
+            batch['coord'] = batch['coord'][None]
+            batch['box'] = batch['box'][None]
+            if 'force' in batch:
+                batch['force'] = batch['force'][None]
+            if 'energy' in batch:
+                batch['energy'] = np.array([batch['energy']])
+            for l in list(batch.keys()):
+                if 'atomic' in l:
+                    batch[l] = batch[l][None]
             # Compute type_count for the single frame based on mapped types
             types = batch['type']
             type_count = np.array([(types == i).sum() for i in range(self.ntypes)])

--- a/deepmd_jax/data.py
+++ b/deepmd_jax/data.py
@@ -6,6 +6,16 @@ from os.path import abspath
 from ase.io import read
 from .utils import shift, get_relative_coord, sr
 
+def _classify_path(p):
+    return 'extxyz' if isinstance(p, str) and p.lower().endswith(('.xyz', '.extxyz')) else 'dp'
+
+def _flatten_paths(paths):
+    for p in paths:
+        if isinstance(p, list):
+            yield from _flatten_paths(p)
+        else:
+            yield p
+
 class Dataset():
     def __init__(self, paths, labels, params={}, chemical_types=None, _in_memory=None):
         '''
@@ -29,6 +39,10 @@ class Dataset():
             self._finalize_leaf(_in_memory['type'], _in_memory['data'], labels, params, paths=None)
             return
 
+        formats = {_classify_path(p) for p in _flatten_paths(paths)}
+        if len(formats) > 1:
+            raise ValueError('Mixing DP-directory and extxyz dataset paths is not supported; got both in %s' % (paths,))
+
         if type(paths[0]) == list:
             self.is_leaf = False
             self.subsets = [Dataset(path, labels, params, chemical_types=chemical_types)
@@ -36,7 +50,7 @@ class Dataset():
             self._finalize_non_leaf()
             return
 
-        if isinstance(paths[0], str) and paths[0].lower().endswith(('.xyz', '.extxyz')):
+        if formats == {'extxyz'}:
             self._init_from_extxyz(paths, labels, params)
             return
 

--- a/deepmd_jax/data.py
+++ b/deepmd_jax/data.py
@@ -165,31 +165,43 @@ class EXTXYZDataset():
                     atoms_list = [atoms_list]
                 for atoms in atoms_list:
                     frame = {}
-                    frame['box'] = np.asarray(atoms.get_cell().array, dtype=np.float32)
-                    frame['coord'] = np.asarray(atoms.get_positions(), dtype=np.float32)
-                    frame['coord'] = np.array(shift(frame['coord'], frame['box']))
-                    frame['atomic_numbers'] = np.asarray(atoms.get_atomic_numbers(), dtype=int)
-                    if 'force' in labels:
-                        try:
-                            frame['force'] = np.asarray(atoms.get_forces(), dtype=np.float32)
-                        except RuntimeError:
-                            raise ValueError('Extended xyz file missing forces for frame in %s' % path)
-                    if 'energy' in labels:
-                        try:
-                            energy = atoms.get_potential_energy()
-                            if energy is None:
-                                raise ValueError('Extended xyz file missing energy for frame in %s' % path)
-                            frame['energy'] = np.asarray(energy, dtype=np.float32)
-                        except RuntimeError:
-                            raise ValueError('Extended xyz file missing energy for frame in %s' % path)
+                    try:
+                        frame['atomic_numbers'] = np.asarray(atoms.get_atomic_numbers(), dtype=int)
+                    except RuntimeError:
+                        raise ValueError('Extended xyz file missing atomic numbers for frame in %s' % path)
                     for l in labels:
-                        if 'atomic' in l and l not in frame:
+                        if l == 'box':
+                            try:
+                                frame['box'] = np.asarray(atoms.get_cell().array, dtype=np.float32)
+                            except RuntimeError:
+                                raise ValueError('Extended xyz file missing box for frame in %s' % path)
+                        elif l == 'coord':
+                            try:
+                                frame['coord'] = np.asarray(atoms.get_positions(), dtype=np.float32)
+                            except RuntimeError:
+                                raise ValueError('Extended xyz file missing coord for frame in %s' % path)
+                        elif l == 'force':
+                            try:
+                                frame['force'] = np.asarray(atoms.get_forces(), dtype=np.float32)
+                            except RuntimeError:
+                                raise ValueError('Extended xyz file missing forces for frame in %s' % path)
+                        elif l == 'energy':
+                            try:
+                                energy = atoms.get_potential_energy()
+                                if energy is None:
+                                    raise ValueError('Extended xyz file missing energy for frame in %s' % path)
+                                frame['energy'] = np.asarray(energy, dtype=np.float32)
+                            except RuntimeError:
+                                raise ValueError('Extended xyz file missing energy for frame in %s' % path)
+                        else:
                             if l in atoms.arrays:
                                 frame[l] = np.asarray(atoms.arrays[l], dtype=np.float32)
+                            elif l in atoms.info:
+                                frame[l] = np.asarray(atoms.info[l], dtype=np.float32)
                             else:
-                                raise ValueError('Atomic label %s not found in frame arrays for %s' % (l, path))
-                    if 'cell' in labels and 'cell' not in frame:
-                        frame['cell'] = frame['box']
+                                raise ValueError('Atomic label %s not found in frame arrays or info for %s' % (l, path))
+                    if 'coord' in frame and 'box' in frame:
+                        frame['coord'] = np.array(shift(frame['coord'], frame['box']))
                     self.frames.append(frame)
             # Map atomic numbers to types
             all_atomic_numbers = set()
@@ -201,16 +213,12 @@ class EXTXYZDataset():
             self.valid_types = np.arange(self.ntypes)
             for frame in self.frames:
                 frame['type'] = np.array([self.atomic_to_type[an] for an in frame['atomic_numbers']], dtype=int)
-                # --- sort atoms by type (same as DPDataset) ---
                 perm = frame['type'].argsort(kind='stable')
-                frame['type'] = frame['type'][perm]
-                frame['coord'] = frame['coord'][perm]
-                if 'force' in frame:
-                    frame['force'] = frame['force'][perm]
-                # reorder atomic labels
-                #for l in frame:
-                #    if 'atomic' in l:
-                #        frame[l] = frame[l][perm]
+                natoms = len(frame['type'])
+                # Permute all arrays with atom dimension according to sorted types for consistent ordering
+                for k, v in frame.items():
+                    if isinstance(v, np.ndarray) and v.ndim > 0 and v.shape[0] == natoms:
+                        frame[k] = v[perm]
             self.nframes = len(self.frames)
             self.order = np.arange(self.nframes)
             self.pointer = self.nframes

--- a/deepmd_jax/data.py
+++ b/deepmd_jax/data.py
@@ -1,3 +1,5 @@
+from operator import index
+
 import numpy as np
 import jax.numpy as jnp
 from jax import vmap
@@ -165,8 +167,9 @@ class EXTXYZDataset():
                     atoms_list = [atoms_list]
                 for atoms in atoms_list:
                     frame = {}
-                    frame['coord'] = np.asarray(atoms.get_positions(), dtype=np.float32)
                     frame['box'] = np.asarray(atoms.get_cell().array, dtype=np.float32)
+                    frame['coord'] = np.asarray(atoms.get_positions(), dtype=np.float32)
+                    frame['coord'] = np.array(shift(frame['coord'], frame['box']))
                     frame['atomic_numbers'] = np.asarray(atoms.get_atomic_numbers(), dtype=int)
                     if 'force' in labels:
                         try:
@@ -189,8 +192,6 @@ class EXTXYZDataset():
                                 raise ValueError('Atomic label %s not found in frame arrays for %s' % (l, path))
                     if 'cell' in labels and 'cell' not in frame:
                         frame['cell'] = frame['box']
-                    if 'type' in labels and 'type' not in frame:
-                        frame['type'] = frame['atomic_numbers']
                     self.frames.append(frame)
             # Map atomic numbers to types
             all_atomic_numbers = set()
@@ -202,6 +203,16 @@ class EXTXYZDataset():
             self.valid_types = np.arange(self.ntypes)
             for frame in self.frames:
                 frame['type'] = np.array([self.atomic_to_type[an] for an in frame['atomic_numbers']], dtype=int)
+                # --- sort atoms by type (same as DPDataset) ---
+                perm = frame['type'].argsort(kind='stable')
+                frame['type'] = frame['type'][perm]
+                frame['coord'] = frame['coord'][perm]
+                if 'force' in frame:
+                    frame['force'] = frame['force'][perm]
+                # reorder atomic labels
+                #for l in frame:
+                #    if 'atomic' in l:
+                #        frame[l] = frame[l][perm]
             self.nframes = len(self.frames)
             self.order = np.arange(self.nframes)
             self.pointer = self.nframes
@@ -237,7 +248,8 @@ class EXTXYZDataset():
                 np.random.shuffle(self.order)
             index = self.order[self.pointer]
             self.pointer += batch_size
-            batch = self.frames[index]
+            batch = {k: v.copy() if isinstance(v, np.ndarray) else v
+                     for k, v in self.frames[index].items()}
             batch['coord'] = batch['coord'][None]
             batch['box'] = batch['box'][None]
             if 'force' in batch:

--- a/deepmd_jax/md.py
+++ b/deepmd_jax/md.py
@@ -265,7 +265,10 @@ class Simulation:
             Initialize a Simulation instance.
             model_path: path to the deepmd model
             box: box size, scalar or (3,) or (3,3)
-            type_idx: list of atom types, length = n_atoms
+            type_idx: list of atom types, length = n_atoms. If the loaded model stores
+                model.params['chemical_types'] (i.e. was trained from extxyz or with chemical_types
+                supplied), type_idx is interpreted as atomic numbers (Z); otherwise as integer
+                type indices in the range [0, ntypes).
             mass: atomic mass for each type, length = number of atom types
             routine: simulation routine, currently limited to 'NVE', 'NVT', 'NPT', where NVT/NPT uses Nose-Hoover thermostat/barostat
             dt: time step size (fs)
@@ -299,9 +302,18 @@ class Simulation:
         self._dt = dt
         self._routine = routine
         self._temperature = temperature
-        self._type_idx = np.array(type_idx).astype(int)
-        self._mass = jnp.array(np.array(mass)[np.array(self._type_idx)]) # AMU
         self._model, self._variables = load_model(model_path)
+        type_idx_np = np.array(type_idx).astype(int)
+        ct = self._model.params.get('chemical_types')
+        if ct is not None:
+            unknown = set(type_idx_np.tolist()) - set(ct)
+            if unknown:
+                raise ValueError('Atomic numbers %s in type_idx are not in model.params["chemical_types"]=%s'
+                                 % (sorted(unknown), ct))
+            z_to_idx = {z: i for i, z in enumerate(ct)}
+            type_idx_np = np.array([z_to_idx[z] for z in type_idx_np], dtype=int)
+        self._type_idx = type_idx_np
+        self._mass = jnp.array(np.array(mass)[np.array(self._type_idx)]) # AMU
         type_count = np.bincount(self._type_idx)
         self._type_count = np.pad(type_count, (0, self._model.params['ntypes'] - len(type_count)))
         self._debug = debug

--- a/deepmd_jax/md.py
+++ b/deepmd_jax/md.py
@@ -1234,7 +1234,16 @@ class DPJaxCalculator(Calculator):
         self._model, self._variables = load_model(model_path)
         self._static_args = None
 
-        self._type_idx = np.array(type_idx).astype(int)
+        type_idx_np = np.array(type_idx).astype(int)
+        ct = self._model.params.get('chemical_types')
+        if ct is not None:
+            unknown = set(type_idx_np.tolist()) - set(ct)
+            if unknown:
+                raise ValueError('Atomic numbers %s in type_idx are not in model.params["chemical_types"]=%s'
+                                 % (sorted(unknown), ct))
+            z_to_idx = {z: i for i, z in enumerate(ct)}
+            type_idx_np = np.array([z_to_idx[z] for z in type_idx_np], dtype=int)
+        self._type_idx = type_idx_np
         type_count = np.bincount(self._type_idx)
         self._type_count = np.pad(type_count, (0, self._model.params['ntypes'] - len(type_count)))
 

--- a/deepmd_jax/train.py
+++ b/deepmd_jax/train.py
@@ -165,7 +165,7 @@ def train(
     else:
         train_data_path = [[path] for path in train_data_path]
     first_path = train_data_path[0] if isinstance(train_data_path[0], str) else train_data_path[0][0]
-    if model_type in ('energy', 'dplr') and isinstance(first_path, str) and first_path.lower().endswith(('.xyz', '.extxyz')):
+    if isinstance(first_path, str) and first_path.lower().endswith(('.xyz', '.extxyz')):
         train_data = EXTXYZDataset(train_data_path,
                                    labels,
                                    {'atomic_sel':atomic_sel})
@@ -251,9 +251,14 @@ def train(
         # Load observable data
         train_data_obs = []
         for i in range(n_paths):
-            single_data_obs = DPDataset([obs_train_data_path[i]],
-                                        labels_obs,
-                                        {'atomic_sel':atomic_sel})
+            if isinstance(obs_train_data_path[i], str) and obs_train_data_path[i].lower().endswith(('.xyz', '.extxyz')):
+                single_data_obs = EXTXYZDataset([obs_train_data_path[i]],
+                                           labels_obs,
+                                           {'atomic_sel':atomic_sel})
+            else:
+                single_data_obs = DPDataset([obs_train_data_path[i]],
+                                       labels_obs,
+                                       {'atomic_sel':atomic_sel})
             single_data_obs.compute_lattice_candidate(rcut)
             train_data_obs.append(single_data_obs)
 
@@ -264,7 +269,7 @@ def train(
         else:
             val_data_path = [[path] for path in val_data_path]
         first_val_path = val_data_path[0] if isinstance(val_data_path[0], str) else val_data_path[0][0]
-        if model_type in ('energy', 'dplr') and isinstance(first_val_path, str) and first_val_path.lower().endswith(('.xyz', '.extxyz')):
+        if isinstance(first_val_path, str) and first_val_path.lower().endswith(('.xyz', '.extxyz')):
             val_data = EXTXYZDataset(val_data_path,
                                      labels,
                                      {'atomic_sel':atomic_sel})

--- a/deepmd_jax/train.py
+++ b/deepmd_jax/train.py
@@ -6,7 +6,7 @@ import time, datetime
 import flax.linen as nn
 from functools import partial
 from .utils import get_p3mlr_fn, get_p3mlr_grid_size, load_model, save_model, compress_model, save_dataset
-from .data import DPDataset
+from .data import DPDataset, EXTXYZDataset
 from .dpmodel import DPModel
 from typing import Union, List
 import tempfile
@@ -164,9 +164,15 @@ def train(
         train_data_path = [train_data_path]
     else:
         train_data_path = [[path] for path in train_data_path]
-    train_data = DPDataset(train_data_path,
-                           labels,
-                           {'atomic_sel':atomic_sel})
+    first_path = train_data_path[0] if isinstance(train_data_path[0], str) else train_data_path[0][0]
+    if model_type in ('energy', 'dplr') and isinstance(first_path, str) and first_path.lower().endswith(('.xyz', '.extxyz')):
+        train_data = EXTXYZDataset(train_data_path,
+                                   labels,
+                                   {'atomic_sel':atomic_sel})
+    else:
+        train_data = DPDataset(train_data_path,
+                               labels,
+                               {'atomic_sel':atomic_sel})
     train_data.compute_lattice_candidate(rcut)
 
     # Setup for hybrid training
@@ -257,9 +263,15 @@ def train(
             val_data_path = [val_data_path]
         else:
             val_data_path = [[path] for path in val_data_path]
-        val_data = DPDataset(val_data_path,
-                             labels,
-                             {'atomic_sel':atomic_sel})
+        first_val_path = val_data_path[0] if isinstance(val_data_path[0], str) else val_data_path[0][0]
+        if model_type in ('energy', 'dplr') and isinstance(first_val_path, str) and first_val_path.lower().endswith(('.xyz', '.extxyz')):
+            val_data = EXTXYZDataset(val_data_path,
+                                     labels,
+                                     {'atomic_sel':atomic_sel})
+        else:
+            val_data = DPDataset(val_data_path,
+                                 labels,
+                                 {'atomic_sel':atomic_sel})
         val_data.compute_lattice_candidate(rcut)
     else:
         val_data = None

--- a/deepmd_jax/train.py
+++ b/deepmd_jax/train.py
@@ -6,7 +6,7 @@ import time, datetime
 import flax.linen as nn
 from functools import partial
 from .utils import get_p3mlr_fn, get_p3mlr_grid_size, load_model, save_model, compress_model, save_dataset
-from .data import DPDataset, EXTXYZDataset
+from .data import Dataset
 from .dpmodel import DPModel
 from typing import Union, List
 import tempfile
@@ -164,16 +164,11 @@ def train(
         train_data_path = [train_data_path]
     else:
         train_data_path = [[path] for path in train_data_path]
-    first_path = train_data_path[0] if isinstance(train_data_path[0], str) else train_data_path[0][0]
-    if isinstance(first_path, str) and first_path.lower().endswith(('.xyz', '.extxyz')):
-        train_data = EXTXYZDataset(train_data_path,
-                                   labels,
-                                   {'atomic_sel':atomic_sel})
-    else:
-        train_data = DPDataset(train_data_path,
-                               labels,
-                               {'atomic_sel':atomic_sel})
+    train_data = Dataset(train_data_path,
+                           labels,
+                           {'atomic_sel':atomic_sel})
     train_data.compute_lattice_candidate(rcut)
+    chemical_types = train_data.chemical_types
 
     # Setup for hybrid training
     if hybrid:
@@ -251,14 +246,10 @@ def train(
         # Load observable data
         train_data_obs = []
         for i in range(n_paths):
-            if isinstance(obs_train_data_path[i], str) and obs_train_data_path[i].lower().endswith(('.xyz', '.extxyz')):
-                single_data_obs = EXTXYZDataset([obs_train_data_path[i]],
-                                           labels_obs,
-                                           {'atomic_sel':atomic_sel})
-            else:
-                single_data_obs = DPDataset([obs_train_data_path[i]],
-                                       labels_obs,
-                                       {'atomic_sel':atomic_sel})
+            single_data_obs = Dataset([obs_train_data_path[i]],
+                                        labels_obs,
+                                        {'atomic_sel':atomic_sel},
+                                        chemical_types=chemical_types)
             single_data_obs.compute_lattice_candidate(rcut)
             train_data_obs.append(single_data_obs)
 
@@ -268,15 +259,10 @@ def train(
             val_data_path = [val_data_path]
         else:
             val_data_path = [[path] for path in val_data_path]
-        first_val_path = val_data_path[0] if isinstance(val_data_path[0], str) else val_data_path[0][0]
-        if isinstance(first_val_path, str) and first_val_path.lower().endswith(('.xyz', '.extxyz')):
-            val_data = EXTXYZDataset(val_data_path,
-                                     labels,
-                                     {'atomic_sel':atomic_sel})
-        else:
-            val_data = DPDataset(val_data_path,
-                                 labels,
-                                 {'atomic_sel':atomic_sel})
+        val_data = Dataset(val_data_path,
+                             labels,
+                             {'atomic_sel':atomic_sel},
+                             chemical_types=chemical_types)
         val_data.compute_lattice_candidate(rcut)
     else:
         val_data = None
@@ -570,14 +556,10 @@ def test(
         atomic_sel = model.params['nsel']
     else:
         raise ValueError('Model type should be "energy", "atomic", "atomic_t2", or "dplr".')
-    if isinstance(data_path, str) and data_path.lower().endswith(('.xyz', '.extxyz')):
-        test_data = EXTXYZDataset([data_path],
-                                   labels,
-                                   {'atomic_sel':atomic_sel})
-    else:
-        test_data = DPDataset([data_path],
-                               labels,
-                               {'atomic_sel':atomic_sel})
+    test_data = Dataset([data_path],
+                          labels,
+                          {'atomic_sel':atomic_sel},
+                          chemical_types=model.params.get('chemical_types'))
     test_data.compute_lattice_candidate(model.params['rcut'])
     if 'dplr' in model.params['type']:
         subsets = test_data.get_flattened_data()
@@ -588,8 +570,6 @@ def test(
                                       model.params['dplr_beta'],
                                       model.params['dplr_resolution'],
                                       *model.params['dplr_wannier_model_and_variables'])
-    test_data.pointer = 0
-    remaining = test_data.nframes
 
     if model.params['type'] in ['energy', 'dplr']:
         evaluate_fn = model.energy_and_force
@@ -626,65 +606,68 @@ def test(
         static_argnames=('static_args',)
     )
 
-    while remaining > 0:
-        bs = min(batch_size, remaining)
-        batch, type_count, lattice_args = test_data.get_batch(bs)
-        remaining -= bs
+    for leaf in test_data.get_leaves():
+        leaf.pointer = 0
+        remaining = leaf.nframes
+        while remaining > 0:
+            bs = min(batch_size, remaining)
+            batch, type_count, lattice_args = leaf.get_batch(bs)
+            remaining -= bs
 
-        static_args = nn.FrozenDict({'type_count': type_count, 'lattice': lattice_args})
-        pred = evaluate_fn(variables, batch['coord'], batch['box'], static_args)
+            static_args = nn.FrozenDict({'type_count': type_count, 'lattice': lattice_args})
+            pred = evaluate_fn(variables, batch['coord'], batch['box'], static_args)
 
-        if model.params['type'] in ['energy', 'dplr']:
-            E_pred, F_pred = pred
-            E_true = batch['energy']
-            F_true = batch['force']
+            if model.params['type'] in ['energy', 'dplr']:
+                E_pred, F_pred = pred
+                E_true = batch['energy']
+                F_true = batch['force']
 
-            # store if desired
-            predictions['energy'].append(E_pred)
-            predictions['force'].append(F_pred)
-            ground_truth['energy'].append(E_true)
-            ground_truth['force'].append(F_true)
+                # store if desired
+                predictions['energy'].append(E_pred)
+                predictions['force'].append(F_pred)
+                ground_truth['energy'].append(E_true)
+                ground_truth['force'].append(F_true)
 
-            # --- ENERGY (per-atom normalized) ---
-            natoms = F_pred.shape[1]
+                # --- ENERGY (per-atom normalized) ---
+                natoms = F_pred.shape[1]
 
-            dE = (E_pred - E_true) / natoms
-            stats['energy']['sq'] += (dE**2).sum()
-            stats['energy']['abs'] += np.abs(dE).sum()
-            stats['energy']['count'] += dE.size
+                dE = (E_pred - E_true) / natoms
+                stats['energy']['sq'] += (dE**2).sum()
+                stats['energy']['abs'] += np.abs(dE).sum()
+                stats['energy']['count'] += dE.size
 
-            stats['energy_l1_sum'] += np.abs(dE).sum()
-            stats['energy_l1_count'] += dE.size
+                stats['energy_l1_sum'] += np.abs(dE).sum()
+                stats['energy_l1_count'] += dE.size
 
-            # --- FORCES ---
-            diffF = F_pred - F_true
+                # --- FORCES ---
+                diffF = F_pred - F_true
 
-            stats['force']['sq'] += (diffF**2).sum()
-            stats['force']['abs'] += np.abs(diffF).sum()
-            stats['force']['count'] += diffF.size
+                stats['force']['sq'] += (diffF**2).sum()
+                stats['force']['abs'] += np.abs(diffF).sum()
+                stats['force']['count'] += diffF.size
 
-            # mixed L1 (per-atom norm)
-            per_atom = (diffF**2).mean(-1)**0.5
-            stats['force_l1_sum'] += per_atom.sum()
-            stats['force_l1_count'] += per_atom.size
+                # mixed L1 (per-atom norm)
+                per_atom = (diffF**2).mean(-1)**0.5
+                stats['force_l1_sum'] += per_atom.sum()
+                stats['force_l1_count'] += per_atom.size
 
-        else:
-            key = model.params['atomic_data_prefix']
-            pred_val = pred[0]
-            true_val = batch['atomic']
+            else:
+                key = model.params['atomic_data_prefix']
+                pred_val = pred[0]
+                true_val = batch['atomic']
 
-            predictions[key].append(pred_val)
-            ground_truth[key].append(true_val)
+                predictions[key].append(pred_val)
+                ground_truth[key].append(true_val)
 
-            diff = pred_val - true_val
+                diff = pred_val - true_val
 
-            stats[key]['sq'] += (diff**2).sum()
-            stats[key]['abs'] += np.abs(diff).sum()
-            stats[key]['count'] += diff.size
+                stats[key]['sq'] += (diff**2).sum()
+                stats[key]['abs'] += np.abs(diff).sum()
+                stats[key]['count'] += diff.size
 
-            per_atom = (diff**2).mean(-1)**0.5
-            stats['l1_sum'] += per_atom.sum()
-            stats['l1_count'] += per_atom.size
+                per_atom = (diff**2).mean(-1)**0.5
+                stats['l1_sum'] += per_atom.sum()
+                stats['l1_count'] += per_atom.size
 
     # --- FINAL METRICS ---
     rmse = {}
@@ -723,7 +706,8 @@ def evaluate(
             model_path: path to the trained model.
             coord: atomic coordinates of shape (n_frames, n_atoms, 3).
             box: simulation box of shape (n_frames) + (,) or (1,) or (3,) or (9), or (3,3).
-            type_idx: atomic type indices of shape (Natoms,)
+            type_idx: atomic type indices of shape (Natoms,). If the model was trained with
+                chemical_types (extxyz path), type_idx is interpreted as atomic numbers (Z).
             batch_size: Increase for potentially faster evaluation, but requires more memory.
     '''
     # input shape check
@@ -750,6 +734,15 @@ def evaluate(
                          'type_idx (n_atoms).')
     
     model, _ = load_model(model_path, replicate=False)
+    ct = model.params.get('chemical_types')
+    if ct is not None:
+        type_idx_np = np.array(type_idx, dtype=int)
+        unknown = set(type_idx_np.tolist()) - set(ct)
+        if unknown:
+            raise ValueError('Atomic numbers %s in type_idx are not in model.params["chemical_types"]=%s'
+                             % (sorted(unknown), ct))
+        z_to_idx = {z: i for i, z in enumerate(ct)}
+        type_idx = np.array([z_to_idx[z] for z in type_idx_np], dtype=int)
 
     # create dataset in temp directory and use test() to evaluate
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/deepmd_jax/train.py
+++ b/deepmd_jax/train.py
@@ -160,10 +160,6 @@ def train(
         assert type(atomic_sel) == list, ' Must provide atomic_sel properly for model_type "atomic"/"atomic_t2".'
     else:
         raise ValueError('model_type should be "energy", "atomic", "atomic_t2", or "dplr".')
-    if type(train_data_path) == str:
-        train_data_path = [train_data_path]
-    else:
-        train_data_path = [[path] for path in train_data_path]
     train_data = Dataset(train_data_path,
                            labels,
                            {'atomic_sel':atomic_sel})
@@ -246,7 +242,7 @@ def train(
         # Load observable data
         train_data_obs = []
         for i in range(n_paths):
-            single_data_obs = Dataset([obs_train_data_path[i]],
+            single_data_obs = Dataset(obs_train_data_path[i],
                                         labels_obs,
                                         {'atomic_sel':atomic_sel},
                                         chemical_types=chemical_types)
@@ -255,10 +251,6 @@ def train(
 
     use_val_data = val_data_path is not None
     if use_val_data:
-        if type(val_data_path) == str:
-            val_data_path = [val_data_path]
-        else:
-            val_data_path = [[path] for path in val_data_path]
         val_data = Dataset(val_data_path,
                              labels,
                              {'atomic_sel':atomic_sel},
@@ -556,7 +548,7 @@ def test(
         atomic_sel = model.params['nsel']
     else:
         raise ValueError('Model type should be "energy", "atomic", "atomic_t2", or "dplr".')
-    test_data = Dataset([data_path],
+    test_data = Dataset(data_path,
                           labels,
                           {'atomic_sel':atomic_sel},
                           chemical_types=model.params.get('chemical_types'))

--- a/deepmd_jax/train.py
+++ b/deepmd_jax/train.py
@@ -570,9 +570,14 @@ def test(
         atomic_sel = model.params['nsel']
     else:
         raise ValueError('Model type should be "energy", "atomic", "atomic_t2", or "dplr".')
-    test_data = DPDataset([data_path],
-                          labels,
-                          {'atomic_sel':atomic_sel})
+    if isinstance(data_path, str) and data_path.lower().endswith(('.xyz', '.extxyz')):
+        test_data = EXTXYZDataset([data_path],
+                                   labels,
+                                   {'atomic_sel':atomic_sel})
+    else:
+        test_data = DPDataset([data_path],
+                               labels,
+                               {'atomic_sel':atomic_sel})
     test_data.compute_lattice_candidate(model.params['rcut'])
     if 'dplr' in model.params['type']:
         subsets = test_data.get_flattened_data()

--- a/deepmd_jax/train.py
+++ b/deepmd_jax/train.py
@@ -590,51 +590,124 @@ def test(
                                       *model.params['dplr_wannier_model_and_variables'])
     test_data.pointer = 0
     remaining = test_data.nframes
-    if model.params['type'] == 'energy' or model.params['type'] == 'dplr':
+
+    if model.params['type'] in ['energy', 'dplr']:
         evaluate_fn = model.energy_and_force
+
+        # running stats
+        stats = {
+            'energy': {'sq': 0.0, 'abs': 0.0, 'count': 0},
+            'force': {'sq': 0.0, 'abs': 0.0, 'count': 0},
+            'force_l1_sum': 0.0,
+            'force_l1_count': 0,
+            'energy_l1_sum': 0.0,
+            'energy_l1_count': 0,
+        }
+
+        # optional storage
         predictions = {'energy': [], 'force': []}
         ground_truth = {'energy': [], 'force': []}
+
     else:
+        key = model.params['atomic_data_prefix']
         evaluate_fn = lambda variables, coord, box, static_args: model.apply(variables, coord, box, static_args)
-        predictions = {model.params['atomic_data_prefix']: []}
-        ground_truth = {model.params['atomic_data_prefix']: []}
-    evaluate_fn = jax.jit(jax.vmap(evaluate_fn,
-                                   in_axes=(None,0,0,None)),
-                                   static_argnames=('static_args',))
+
+        stats = {
+            key: {'sq': 0.0, 'abs': 0.0, 'count': 0},
+            'l1_sum': 0.0,
+            'l1_count': 0,
+        }
+
+        predictions = {key: []}
+        ground_truth = {key: []}
+
+    evaluate_fn = jax.jit(
+        jax.vmap(evaluate_fn, in_axes=(None, 0, 0, None)),
+        static_argnames=('static_args',)
+    )
+
     while remaining > 0:
         bs = min(batch_size, remaining)
         batch, type_count, lattice_args = test_data.get_batch(bs)
         remaining -= bs
+
         static_args = nn.FrozenDict({'type_count': type_count, 'lattice': lattice_args})
         pred = evaluate_fn(variables, batch['coord'], batch['box'], static_args)
-        if model.params['type'] == 'energy' or model.params['type'] == 'dplr':
-            predictions['energy'].append(pred[0])
-            predictions['force'].append(pred[1])
-            ground_truth['energy'].append(batch['energy'])
-            ground_truth['force'].append(batch['force'])
+
+        if model.params['type'] in ['energy', 'dplr']:
+            E_pred, F_pred = pred
+            E_true = batch['energy']
+            F_true = batch['force']
+
+            # store if desired
+            predictions['energy'].append(E_pred)
+            predictions['force'].append(F_pred)
+            ground_truth['energy'].append(E_true)
+            ground_truth['force'].append(F_true)
+
+            # --- ENERGY (per-atom normalized) ---
+            natoms = F_pred.shape[1]
+
+            dE = (E_pred - E_true) / natoms
+            stats['energy']['sq'] += (dE**2).sum()
+            stats['energy']['abs'] += np.abs(dE).sum()
+            stats['energy']['count'] += dE.size
+
+            stats['energy_l1_sum'] += np.abs(dE).sum()
+            stats['energy_l1_count'] += dE.size
+
+            # --- FORCES ---
+            diffF = F_pred - F_true
+
+            stats['force']['sq'] += (diffF**2).sum()
+            stats['force']['abs'] += np.abs(diffF).sum()
+            stats['force']['count'] += diffF.size
+
+            # mixed L1 (per-atom norm)
+            per_atom = (diffF**2).mean(-1)**0.5
+            stats['force_l1_sum'] += per_atom.sum()
+            stats['force_l1_count'] += per_atom.size
+
         else:
-            predictions[model.params['atomic_data_prefix']].append(pred[0])
-            ground_truth[model.params['atomic_data_prefix']].append(batch['atomic'])
+            key = model.params['atomic_data_prefix']
+            pred_val = pred[0]
+            true_val = batch['atomic']
+
+            predictions[key].append(pred_val)
+            ground_truth[key].append(true_val)
+
+            diff = pred_val - true_val
+
+            stats[key]['sq'] += (diff**2).sum()
+            stats[key]['abs'] += np.abs(diff).sum()
+            stats[key]['count'] += diff.size
+
+            per_atom = (diff**2).mean(-1)**0.5
+            stats['l1_sum'] += per_atom.sum()
+            stats['l1_count'] += per_atom.size
+
+    # --- FINAL METRICS ---
     rmse = {}
     mae = {}
     l1_mixed = {}
-    for key in predictions.keys():
-        predictions[key] = np.concatenate(predictions[key], axis=0)
-        ground_truth[key] = np.concatenate(ground_truth[key], axis=0)
-        rmse[key] = (((predictions[key] - ground_truth[key]) ** 2).mean() ** 0.5).item()
-        mae[key] = np.abs(predictions[key] - ground_truth[key]).mean().item()
-    # reorder force back; will delete in future when reordering is moved into dpmodel.py
-    if model.params['type'] == 'energy' or model.params['type'] == 'dplr':
-        ground_truth['force'] = ground_truth['force'][:, test_data.type.argsort(kind='stable').argsort(kind='stable')]
-        predictions['force'] = predictions['force'][:, test_data.type.argsort(kind='stable').argsort(kind='stable')]
-        natoms = predictions['force'].shape[1]
-        rmse['energy'] /= natoms
-        mae['energy'] /= natoms
-        l1_mixed['energy'] = (np.abs(predictions['energy'] - ground_truth['energy']).mean() / natoms).item()
-        l1_mixed['force'] = (((predictions['force'] - ground_truth['force'])**2).mean(-1)**0.5).mean().item()
+
+    if model.params['type'] in ['energy', 'dplr']:
+        rmse['energy'] = (stats['energy']['sq'] / stats['energy']['count'])**0.5
+        mae['energy'] = stats['energy']['abs'] / stats['energy']['count']
+
+        rmse['force'] = (stats['force']['sq'] / stats['force']['count'])**0.5
+        mae['force'] = stats['force']['abs'] / stats['force']['count']
+
+        l1_mixed['energy'] = stats['energy_l1_sum'] / stats['energy_l1_count']
+        l1_mixed['force'] = stats['force_l1_sum'] / stats['force_l1_count']
+
     else:
         key = model.params['atomic_data_prefix']
-        l1_mixed[key] = (((predictions[key] - ground_truth[key])**2).mean(-1)**0.5).mean().item()
+
+        rmse[key] = (stats[key]['sq'] / stats[key]['count'])**0.5
+        mae[key] = stats[key]['abs'] / stats[key]['count']
+        l1_mixed[key] = stats['l1_sum'] / stats['l1_count']
+
     return rmse, mae, l1_mixed, predictions, ground_truth
         
 def evaluate(


### PR DESCRIPTION
This pull request adds the capability of reading datasets contained in extended xyz files. Many datasets are distributed in this format and they can have a variable number of atoms in each frame. I have implemented a new class inside `data.py` named `EXTXYZDataset` that reads this type of file. There are some special considerations and for this reason this is work in progress:
- Because the dataset can have a variable number of atoms, I had to enforce a batch size of one. The way the coordinates and forces are passed by `get_batch()` assumes fixed shape matrices and this is incompatible with having a different number of atoms per frame. This is a design aspect that could be changed. The current implementation is correct and enforces `batch_size=1`.
-  The `test()` function in `train.py` is also problematic, if one wants to allow the use of `EXTXYZDataset` for the same reason. The arrays computed by this function also assume a constant number of atoms. I have changed this, but perhaps one should think better how to do this.
- The code automatically detects if the path corresponds to a file with extxyz format. This is done in `train.py`, but could be moved to `data.py` with a wrapper class `Dataset` wrapping `DPDataset` and `EXTXYZDataset`.
- Currently one cannot mix DP and EXTXYZ dataset, which could be possible.

@SparkyTruck let me know what you think and thanks!