### PR TITLE
Reuse descriptor-statistics JIT across compatible dataset systems

### DIFF
--- a/deepmd_jax/data.py
+++ b/deepmd_jax/data.py
@@ -3,10 +3,48 @@ import jax
 import jax.numpy as jnp
 from jax import vmap
 from glob import glob
+from functools import partial
 from os.path import abspath
 from time import time
 from ase.io import read
 from .utils import shift, get_relative_coord, get_neighbor_list, get_max_nbrs, neighborlist_is_efficient, sr
+
+
+@partial(jax.jit, static_argnames=(
+    'type_idx', 'type_count', 'rcut', 'lattice_cand', 'lattice_max',
+    'ortho', 'use_neighborlist', 'max_nbrs'))
+def _compute_stats_batch(coord, box, type_idx, type_count, rcut,
+                         lattice_cand, lattice_max, ortho,
+                         use_neighborlist, max_nbrs):
+    lattice_args = {
+        'lattice_cand': lattice_cand,
+        'lattice_max': lattice_max,
+        'ortho': ortho,
+        'use_neighborlist': use_neighborlist,
+        'max_nbrs': max_nbrs,
+    }
+
+    def one_frame(frame):
+        one_coord, one_box = frame
+        nbrs_nm = get_neighbor_list(
+            one_coord, one_box, type_idx, type_count, rcut, max_nbrs, ortho
+        ) if use_neighborlist else None
+        one_coord = one_coord[np.argsort(type_idx, kind='stable')]
+        r_nm = get_relative_coord(
+            one_coord, one_box, type_count, lattice_args, nbrs_nm, K=1)[1]
+        sr_nM = [sr(jnp.concatenate(r, axis=-1), rcut) for r in r_nm]
+        sr_sum = jnp.array([values.sum() for values in sr_nM])
+        sr_sum2 = jnp.array([(values ** 2).sum() for values in sr_nM])
+        sr_count = jnp.array([(values > 1e-15).sum() for values in sr_nM])
+        nnbrs = (jnp.concatenate(sr_nM, axis=0) > 0).sum(1).mean() + 1
+        return jnp.array([
+            sr_sum, sr_sum2, sr_count, nnbrs * jnp.ones_like(sr_sum)
+        ])
+
+    stats = jax.lax.map(one_frame, (coord, box))
+    return jnp.concatenate([
+        stats[:, :3].sum(axis=0), stats[:, 3:].mean(axis=0)
+    ], axis=0)
 
 
 def _classify_path(p):
@@ -127,22 +165,15 @@ class DatasetLeaf:
             raise AttributeError("lattice_args not set. Call compute_lattice_candidate(rcut) before get_stats.")
         batch = self.get_batch(bs)[0]
         type_idx, type_count = tuple(self.type_idx), tuple(self.type_count)
-        def one_frame(coord, box):
-            nbrs_nm = get_neighbor_list(coord, box, type_idx, type_count, rcut,
-                                        self.lattice_args['max_nbrs'],
-                                        self.lattice_args['ortho']) \
-                       if self.lattice_args['use_neighborlist'] else None
-            coord = coord[np.argsort(type_idx, kind='stable')]
-            r_nm = get_relative_coord(coord, box, type_count, self.lattice_args, nbrs_nm, K=1)[1]
-            sr_nM = [sr(jnp.concatenate(r, axis=-1), rcut) for r in r_nm]
-            sr_sum = jnp.array([s.sum() for s in sr_nM])
-            sr_sum2 = jnp.array([(s**2).sum() for s in sr_nM])
-            sr_count = jnp.array([(s > 1e-15).sum() for s in sr_nM])
-            Nnbrs = (jnp.concatenate(sr_nM, axis=0) > 0).sum(1).mean() + 1
-            return jnp.array([sr_sum, sr_sum2, sr_count, Nnbrs*jnp.ones_like(sr_sum)])
-        s = np.array(jax.jit(lambda coord, box: jax.lax.map(lambda x: one_frame(*x), (coord, box)))
-                     (batch['coord'], batch['box']))
-        return np.concatenate([s[:,:3].sum(0), s[:,3:].mean(0)], axis=0)
+        return np.asarray(_compute_stats_batch(
+            batch['coord'], batch['box'], type_idx, type_count, rcut,
+            tuple(self.lattice_args['lattice_cand']),
+            int(self.lattice_args['lattice_max']),
+            bool(self.lattice_args['ortho']),
+            bool(self.lattice_args['use_neighborlist']),
+            (tuple(self.lattice_args['max_nbrs'])
+             if self.lattice_args['max_nbrs'] is not None else None),
+        ))
 
     def get_stats(self, rcut, bs):
         self.params = {'ntypes': self.ntypes, 'rcut': rcut}

--- a/tests/test_data_stats.py
+++ b/tests/test_data_stats.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from deepmd_jax.data import Dataset, _compute_stats_batch
+
+
+def test_shared_stats_jit_matches_previous_result(tmp_path):
+    set_dir = tmp_path / 'set.000'
+    set_dir.mkdir()
+    nframes = 4
+    coords = np.zeros((nframes, 3, 3), dtype=np.float32)
+    coords[:, :, 0] = [
+        [0.0, 1.3, 2.7],
+        [0.0, 1.4, 2.8],
+        [0.0, 1.5, 2.9],
+        [0.0, 1.6, 3.0],
+    ]
+    boxes = np.repeat(
+        (np.eye(3, dtype=np.float32) * 6.0)[None], nframes, axis=0)
+    np.savetxt(tmp_path / 'type.raw', [0, 0, 0], fmt='%d')
+    np.save(set_dir / 'coord.npy', coords.reshape(nframes, -1))
+    np.save(set_dir / 'box.npy', boxes.reshape(nframes, -1))
+    np.save(set_dir / 'energy.npy', np.arange(nframes, dtype=np.float32))
+    np.save(set_dir / 'force.npy', np.zeros((nframes, 9), dtype=np.float32))
+
+    dataset = Dataset(
+        str(tmp_path), ['coord', 'box', 'energy', 'force'])
+    dataset.compute_lattice_candidate(2.5, False)
+    dataset.pointer = 0
+    _compute_stats_batch.clear_cache()
+    stats = dataset.get_stats(2.5, 2)
+    # Upstream dce47eb statistics for the fixed first two frames.
+    np.testing.assert_allclose(stats['sr_mean'], [0.31026190519332886], rtol=0, atol=1e-8)
+    np.testing.assert_allclose(stats['sr_std'], [0.029611550271511078], rtol=0, atol=1e-8)
+    np.testing.assert_allclose(stats['Nnbrs'], 2.3333335, rtol=0, atol=1e-7)
+
+    compiled = _compute_stats_batch._cache_size()
+    assert compiled == 1
+    other = Dataset(str(tmp_path), ['coord', 'box', 'energy', 'force'])
+    other.compute_lattice_candidate(2.5, False)
+    other.pointer = 0
+    repeated = other.get_stats(2.5, 2)
+    assert _compute_stats_batch._cache_size() == compiled
+    for key in ['sr_mean', 'sr_std', 'Nnbrs']:
+        np.testing.assert_array_equal(repeated[key], stats[key])


### PR DESCRIPTION
Descriptor-statistics initialization previously created a new JIT function for each system, preventing compilation reuse across compatible systems. Move the kernel to module scope so systems with matching input shapes and static arguments can reuse the compiled executable.