### PR TITLE
Add deterministic checkpoint/resume support for segmented training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,5 @@ debug_issue*/
 tests/
 *.pkl
 test*
+!tests/
+!tests/*.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Local reliability branch (2026-09-01)
+
+### Added
+- Atomic, SHA256-bound model and training-state writes.
+- Exact segmented checkpoint/resume for model, optimizer, learning-rate step,
+  training/validation samplers, NumPy generators, and JSON history.
+- Deterministic dataset sampling controlled by the public training seed.
+- Fail-closed checkpoint checksum and training-contract validation.
+- Regression tests for uninterrupted/resumed identity, corruption rejection,
+  contract rejection, and DP-MP train/save/reload/test operation.
+
+### Changed
+- `step` now means exactly that many optimizer updates rather than `step + 1`.
+
 ## 0.2.1
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -54,6 +54,38 @@ train(
 
 The default values for the other arguments in [`train()`](https://github.com/SparkyTruck/deepmd-jax/blob/main/deepmd_jax/train.py) like learning rate, batch size, model width, etc. are usually a solid baseline. The one parameter you may want to change is `mp=True` to enable DP-MP for better accuracy.
 
+### Reliable segmented training in this local branch
+
+`step` is the exact total optimizer-update target. A run can checkpoint and
+stop after a bounded number of updates, then resume without changing its
+optimizer, learning-rate, RNG, validation sampler, or training sampler state:
+
+```python
+common = dict(
+    model_type='energy',
+    rcut=6.0,
+    train_data_path=train_paths,
+    val_data_path=validation_paths,
+    save_path='dpmp.pkl',
+    step=500_000,
+    seed=20260901,
+    mp=True,
+    checkpoint_path='dpmp.train.pkl',
+    checkpoint_every=1_000,
+    max_updates_per_run=20_000,
+)
+
+status = train(**common)
+while not status['completed']:
+    status = train(**common, resume=True)
+```
+
+Checkpoints and final models are written atomically with adjacent SHA256
+sidecars. A checkpoint records complete model/optimizer state, the exact
+learning-rate update, all dataset pointers and permutations, and dataset RNG
+states. Resume fails closed on a checksum error or changed training contract.
+The atomic JSON history defaults to `save_path + '.history.json'`.
+
 ### Step 3: Perform a Simulation
 
 Prepare numpy arrays for `initial_position` `(n, 3)`, `box` `()`, `(1,)`, `(3,)`, or `(3, 3)`, and `type_idx` `(n,)`. `mass` gives one mass per atom type.

--- a/deepmd_jax/data.py
+++ b/deepmd_jax/data.py
@@ -21,7 +21,7 @@ def _flatten_paths(paths):
             yield p
 
 
-def Dataset(paths, labels, params=None, chemical_types=None):
+def Dataset(paths, labels, params=None, chemical_types=None, rng=None):
     """
     Create a dataset object from file paths.
 
@@ -54,21 +54,24 @@ def Dataset(paths, labels, params=None, chemical_types=None):
     Constraints:
     - Mixing DP directories and extxyz files in the same paths list is not supported.
     """
+    rng = np.random.default_rng() if rng is None else rng
     flat_paths = [paths] if isinstance(paths, str) else list(_flatten_paths(paths))
     if len(flat_paths) == 1:
         path = flat_paths[0]
         if _classify_path(path) == 'extxyz':
-            return ExtXYZDataset([path], labels, params, chemical_types)
-        return DPDataset(path, labels, params, chemical_types)
+            return ExtXYZDataset([path], labels, params, chemical_types, rng=rng)
+        return DPDataset(path, labels, params, chemical_types, rng=rng)
 
     formats = {_classify_path(p) for p in flat_paths}
     if len(formats) > 1:
         raise ValueError('Mixing DP and extxyz paths is not supported: %s' % (paths,))
 
     if formats == {'extxyz'}:
-        return ExtXYZDataset(flat_paths, labels, params, chemical_types)
-    leaves = [DPDataset(p, labels, params, chemical_types) for p in flat_paths]
-    return DatasetGroup(leaves, chemical_types)
+        return ExtXYZDataset(flat_paths, labels, params, chemical_types, rng=rng)
+    leaves = [DPDataset(p, labels, params, chemical_types,
+                        rng=np.random.default_rng(rng.integers(0, 2**63)))
+              for p in flat_paths]
+    return DatasetGroup(leaves, chemical_types, rng=rng)
 
 
 class DatasetLeaf:
@@ -78,13 +81,15 @@ class DatasetLeaf:
     Data is stored in the input atom order. The model receives ``type_idx`` and
     handles type sorting internally.
     """
-    def __init__(self, labels, params, type_arr, data, paths=None):
+    def __init__(self, labels, params, type_arr, data, paths=None, rng=None):
         self.chemical_types = getattr(self, 'chemical_types', None)
         self.type_idx = np.array(type_arr, dtype=int)
         self.type = self.type_idx
         self.data = data
         self.natoms = len(self.type_idx)
         self.nframes = len(self.data['coord'])
+        self.rng = np.random.default_rng() if rng is None else rng
+        self.order = np.arange(self.nframes, dtype=np.int64)
         for l in labels:
             assert self.data[l].shape[0] == self.nframes, \
                 f"{l}.npy has {self.data[l].shape[0]} frames, expected {self.nframes}"
@@ -161,15 +166,34 @@ class DatasetLeaf:
             batch_size = int(batch_size / self.nlabels + 1)
         if self.pointer + batch_size > self.nframes:
             self.pointer = 0
-            perm = np.random.permutation(self.nframes)
-            self.data = {l: self.data[l][perm] for l in self.data}
+            self.order = self.rng.permutation(self.nframes)
+        indices = self.order[self.pointer:min(self.pointer + batch_size, self.nframes)]
         batch = {
             'atomic' if 'atomic' in l else l:
-            self.data[l][self.pointer:min(self.pointer + batch_size, self.nframes)]
+            self.data[l][indices]
             for l in self.data
         }
-        self.pointer += batch_size
+        self.pointer += len(indices)
         return batch, tuple(self.type_idx), self.lattice_args
+
+    def get_sampler_state(self):
+        return {
+            'pointer': int(self.pointer),
+            'order': self.order.copy(),
+            'rng_state': self.rng.bit_generator.state,
+        }
+
+    def set_sampler_state(self, state):
+        order = np.asarray(state['order'], dtype=np.int64)
+        if order.shape != (self.nframes,) or not np.array_equal(np.sort(order),
+                                                                 np.arange(self.nframes)):
+            raise ValueError('Invalid dataset sampler order in checkpoint.')
+        pointer = int(state['pointer'])
+        if pointer < 0 or pointer > self.nframes:
+            raise ValueError('Invalid dataset sampler pointer in checkpoint.')
+        self.order = order.copy()
+        self.pointer = pointer
+        self.rng.bit_generator.state = state['rng_state']
 
     def compute_lattice_candidate(self, rcut, use_neighbor_list_when_possible=True, mp=False):
         self.lattice_args = compute_lattice_candidate(self.data['box'], rcut)
@@ -228,14 +252,14 @@ class DPDataset(DatasetLeaf):
     Loads data from DP training directories containing type.raw and set.*/ subdirs
     with .npy files. Concatenates data across all sets in the directory.
     """
-    def __init__(self, path, labels, params=None, chemical_types=None):
+    def __init__(self, path, labels, params=None, chemical_types=None, rng=None):
         self.chemical_types = tuple(chemical_types) if chemical_types else None
         type_arr = np.genfromtxt(path + '/type.raw').astype(int)
         data = {
             l: np.concatenate([np.load(s + l + '.npy') for s in sorted(glob(path + '/set.*/'))])
             for l in labels
         }
-        super().__init__(labels, params or {}, type_arr, data, paths=[path])
+        super().__init__(labels, params or {}, type_arr, data, paths=[path], rng=rng)
 
 
 def get_atomic_scalar_stats(dataset, atomic_sel):
@@ -260,8 +284,9 @@ class DatasetGroup:
     subsets is weighted by subset size, stored in self.prob, so larger subsets are
     selected more often during batch generation.
     """
-    def __init__(self, subsets, chemical_types=None):
+    def __init__(self, subsets, chemical_types=None, rng=None):
         self.subsets = subsets
+        self.rng = np.random.default_rng() if rng is None else rng
         self.chemical_types = tuple(chemical_types) if chemical_types else None
         self.nframes = sum([subset.nframes for subset in self.subsets])
         self.ntypes = max([subset.ntypes for subset in self.subsets])
@@ -300,8 +325,21 @@ class DatasetGroup:
         return self.params
 
     def get_batch(self, batch_size, type='frame'):
-        subset = np.random.choice(len(self.subsets), p=self.prob)
+        subset = self.rng.choice(len(self.subsets), p=self.prob)
         return self.subsets[subset].get_batch(batch_size, type)
+
+    def get_sampler_state(self):
+        return {
+            'rng_state': self.rng.bit_generator.state,
+            'subsets': [subset.get_sampler_state() for subset in self.subsets],
+        }
+
+    def set_sampler_state(self, state):
+        if len(state['subsets']) != len(self.subsets):
+            raise ValueError('Dataset subset count does not match checkpoint.')
+        self.rng.bit_generator.state = state['rng_state']
+        for subset, subset_state in zip(self.subsets, state['subsets']):
+            subset.set_sampler_state(subset_state)
 
     def compute_lattice_candidate(self, rcut, use_neighbor_list_when_possible=True, mp=False):
         for subset in self.subsets:
@@ -333,7 +371,8 @@ class ExtXYZDataset(DatasetGroup):
     Parses frames using ASE and groups them by composition before constructing
     internal DatasetLeaf subsets. Each composition group becomes one leaf.
     """
-    def __init__(self, paths, labels, params=None, chemical_types=None):
+    def __init__(self, paths, labels, params=None, chemical_types=None, rng=None):
+        rng = np.random.default_rng() if rng is None else rng
         raw_frames = []
         all_zs = set()
         for path in paths:
@@ -387,9 +426,11 @@ class ExtXYZDataset(DatasetGroup):
             frames = grp['frames']
             data = {l: np.stack([f[l] for f in frames]) for l in labels}
             data['_source_index'] = np.asarray([f['_source_index'] for f in frames], dtype=np.int64)
-            subsets.append(DatasetLeaf(labels, params or {}, grp['type'], data))
+            subsets.append(DatasetLeaf(
+                labels, params or {}, grp['type'], data,
+                rng=np.random.default_rng(rng.integers(0, 2**63))))
 
-        super().__init__(subsets, chemical_types=chemical_types)
+        super().__init__(subsets, chemical_types=chemical_types, rng=rng)
         print('# Dataset loaded (extxyz): %d frames in %d composition group(s). Path:'
               % (len(raw_frames), len(subsets)),
               ''.join(['\n# \t\'%s\'' % abspath(p) for p in paths]))

--- a/deepmd_jax/train.py
+++ b/deepmd_jax/train.py
@@ -21,6 +21,17 @@ import pickle
 
 _CHECKPOINT_VERSION = 1
 
+# Neighbor-derived statistics are reduced through JAX kernels and can differ
+# slightly between CPU and GPU backends even when the dataset and sampling
+# trajectory are identical.  The portable values remain the actual model
+# contract; these tolerances only validate an independently recomputed guard.
+_PORTABLE_DERIVED_TOLERANCES = {
+    'Ebias': (1e-6, 1e-8),
+    'sr_mean': (2e-4, 1e-8),
+    'sr_std': (2e-4, 1e-8),
+    'Nnbrs': (2e-4, 1e-8),
+}
+
 
 def _path_fingerprint(paths):
     if paths is None:
@@ -55,6 +66,46 @@ def _write_history(path, history):
     raw = (json.dumps(history, indent=2, sort_keys=True) + '\n').encode('utf-8')
     _atomic_write_bytes(path, raw)
     _write_sha256_sidecar(path, hashlib.sha256(raw).hexdigest())
+
+
+def _contract_values_equal(left, right):
+    if isinstance(left, dict) and isinstance(right, dict):
+        return (set(left) == set(right)
+                and all(_contract_values_equal(left[key], right[key])
+                        for key in left))
+    if isinstance(left, (list, tuple)) and isinstance(right, (list, tuple)):
+        return (len(left) == len(right)
+                and all(_contract_values_equal(a, b)
+                        for a, b in zip(left, right)))
+    if hasattr(left, 'shape') or hasattr(right, 'shape'):
+        try:
+            return np.array_equal(np.asarray(left), np.asarray(right))
+        except Exception:
+            return False
+    return left == right
+
+
+def _load_portable_model_params(path, computed_params):
+    """Load exact static params while verifying the local data-derived shape."""
+    supplied_sha256 = _verify_sha256_sidecar(path, required=True)
+    with open(path, 'rb') as file:
+        supplied = pickle.load(file)
+    if not isinstance(supplied, dict) or set(supplied) != set(computed_params):
+        raise ValueError('Portable model params have incompatible fields.')
+    for key in supplied:
+        if key in _PORTABLE_DERIVED_TOLERANCES:
+            left, right = np.asarray(supplied[key]), np.asarray(computed_params[key])
+            rtol, atol = _PORTABLE_DERIVED_TOLERANCES[key]
+            if (left.shape != right.shape or left.dtype != right.dtype
+                    or not np.allclose(left, right, rtol=rtol, atol=atol)):
+                raise ValueError(
+                    'Portable model params disagree with local data statistics: '
+                    '%s (rtol=%g, atol=%g).' % (key, rtol, atol))
+        elif not _contract_values_equal(supplied[key], computed_params[key]):
+            raise ValueError(
+                'Portable model params disagree with the model contract: %s.' % key)
+    print('# Loaded content-addressed portable model params from \'%s\'.' % path)
+    return supplied, supplied_sha256
 
 def _get_static_args(type_idx, lattice_args):
     return nn.FrozenDict({'type_idx': tuple(type_idx),
@@ -114,6 +165,7 @@ def train(
     resume: bool = False,
     max_updates_per_run: int = None,
     history_path: str = None,
+    model_params_path: str = None,
 ):
     '''
         Entry point for training deepmd-jax models.
@@ -168,6 +220,11 @@ def train(
             resume: restore checkpoint_path and continue the exact optimizer and sampling trajectory.
             max_updates_per_run: optional segment cap; useful for sub-hour schedulers. The scientific target remains step.
             history_path: atomic JSON training history path. Defaults to save_path + '.history.json'.
+            model_params_path: optional content-addressed pickle of exact static
+                model parameters for a cross-backend resume. The file and its
+                SHA256 sidecar are required, locally recomputed data statistics
+                must agree numerically, and the checkpoint contract must still
+                match the exact serialized parameters. Resume-only.
         --- Input arguments specific for hybrid ab initio and empirical models:
             hybrid: whether to train hybrid ab initio and empirical models.
             obs_train_data_path: paths to training data with trajectories with observable values.
@@ -186,6 +243,10 @@ def train(
         raise ValueError('checkpoint_every must be positive.')
     if max_updates_per_run is not None and max_updates_per_run <= 0:
         raise ValueError('max_updates_per_run must be positive.')
+    if model_params_path is not None and not resume:
+        raise ValueError('model_params_path is only valid when resuming.')
+    if model_params_path is not None and model_type != 'energy':
+        raise ValueError('model_params_path currently supports energy models only.')
     checkpointing = any((checkpoint_path is not None, checkpoint_every is not None,
                          resume, max_updates_per_run is not None))
     if checkpointing and checkpoint_path is None:
@@ -392,6 +453,10 @@ def train(
         'out_norm': scalar_stats[1] if model_type == 'atomic_scalar' else (train_data.get_atomic_label_scale() if 'atomic' in model_type else 1.),
         **train_data.get_stats(rcut, getstat_bs),
     }
+    portable_model_params_sha256 = None
+    if model_params_path is not None:
+        params, portable_model_params_sha256 = _load_portable_model_params(
+            model_params_path, params)
     if model_type == 'dplr':
         dplr_params = {
             'dplr_wannier_model_and_variables': (wc_model, wc_variables),
@@ -452,6 +517,9 @@ def train(
 
     model_params_raw = pickle.dumps(_tree_to_host(model.params),
                                     protocol=pickle.HIGHEST_PROTOCOL)
+    model_params_sha256 = (portable_model_params_sha256
+                           if portable_model_params_sha256 is not None
+                           else hashlib.sha256(model_params_raw).hexdigest())
     contract = {
         'model_type': model_type,
         'rcut': rcut,
@@ -485,7 +553,11 @@ def train(
         'obs_target': obs_target,
         'obs_step_every': obs_step_every,
         'use_neighbor_list_when_possible': use_neighbor_list_when_possible,
-        'model_params_sha256': hashlib.sha256(model_params_raw).hexdigest(),
+        # A portable file is the content-addressed representation accepted by
+        # the source checkpoint. Re-pickling its loaded tree is not a stable
+        # identity operation across NumPy/JAX backends, even when every value
+        # and dtype is unchanged, so retain the already verified file digest.
+        'model_params_sha256': model_params_sha256,
     }
     contract_sha256 = hashlib.sha256(
         pickle.dumps(contract, protocol=pickle.HIGHEST_PROTOCOL)).hexdigest()

--- a/deepmd_jax/train.py
+++ b/deepmd_jax/train.py
@@ -5,12 +5,56 @@ import jax.numpy as jnp
 import time, datetime
 import flax.linen as nn
 from functools import partial
-from .utils import get_p3mlr_fn, get_p3mlr_grid_size, load_model, save_model, compress_model, dplr_charges, get_max_nbrs, neighborlist_is_efficient
+from .utils import (get_p3mlr_fn, get_p3mlr_grid_size, load_model, save_model,
+                    compress_model, dplr_charges, get_max_nbrs,
+                    neighborlist_is_efficient, _atomic_write_bytes,
+                    _write_sha256_sidecar, _verify_sha256_sidecar)
 from .data import Dataset, compute_lattice_candidate, get_atomic_scalar_stats
 from .dpmodel import DPModel
 from typing import Union, List
 import tempfile
 import os
+import hashlib
+import json
+import pickle
+
+
+_CHECKPOINT_VERSION = 1
+
+
+def _path_fingerprint(paths):
+    if paths is None:
+        return None
+    if isinstance(paths, (str, os.PathLike)):
+        return os.path.abspath(os.fspath(paths))
+    return [_path_fingerprint(path) for path in paths]
+
+
+def _tree_to_host(tree):
+    return jax.tree_util.tree_map(
+        lambda value: np.asarray(value) if hasattr(value, 'shape') else value,
+        tree)
+
+
+def _save_training_checkpoint(path, payload):
+    raw = pickle.dumps(payload, protocol=pickle.HIGHEST_PROTOCOL)
+    _atomic_write_bytes(path, raw)
+    _write_sha256_sidecar(path, hashlib.sha256(raw).hexdigest())
+
+
+def _load_training_checkpoint(path):
+    _verify_sha256_sidecar(path, required=True)
+    with open(path, 'rb') as file:
+        payload = pickle.load(file)
+    if payload.get('checkpoint_version') != _CHECKPOINT_VERSION:
+        raise ValueError('Unsupported training checkpoint version.')
+    return payload
+
+
+def _write_history(path, history):
+    raw = (json.dumps(history, indent=2, sort_keys=True) + '\n').encode('utf-8')
+    _atomic_write_bytes(path, raw)
+    _write_sha256_sidecar(path, hashlib.sha256(raw).hexdigest())
 
 def _get_static_args(type_idx, lattice_args):
     return nn.FrozenDict({'type_idx': tuple(type_idx),
@@ -65,6 +109,11 @@ def train(
     obs_target: Union[float, str, list, None] = None,
     obs_step_every: int = 1,
     use_neighbor_list_when_possible: bool = True,
+    checkpoint_path: str = None,
+    checkpoint_every: int = None,
+    resume: bool = False,
+    max_updates_per_run: int = None,
+    history_path: str = None,
 ):
     '''
         Entry point for training deepmd-jax models.
@@ -114,6 +163,11 @@ def train(
                     'l1-mixed': MAE over configs/atoms, but RMS within each force/atomic vector; more robust to data outliers.
                     'l2': MSE over all entries. This was the old default.
             use_neighbor_list_when_possible: use a simple training neighborlist when the lattice candidate count is one.
+            checkpoint_path: atomic training-state checkpoint path. Defaults to save_path + '.train.pkl' when checkpointing is enabled.
+            checkpoint_every: save complete model/optimizer/RNG/sampler state every this many updates.
+            resume: restore checkpoint_path and continue the exact optimizer and sampling trajectory.
+            max_updates_per_run: optional segment cap; useful for sub-hour schedulers. The scientific target remains step.
+            history_path: atomic JSON training history path. Defaults to save_path + '.history.json'.
         --- Input arguments specific for hybrid ab initio and empirical models:
             hybrid: whether to train hybrid ab initio and empirical models.
             obs_train_data_path: paths to training data with trajectories with observable values.
@@ -126,6 +180,22 @@ def train(
     '''
     
     TIC = time.time()
+    if step <= 0:
+        raise ValueError('step must be positive.')
+    if checkpoint_every is not None and checkpoint_every <= 0:
+        raise ValueError('checkpoint_every must be positive.')
+    if max_updates_per_run is not None and max_updates_per_run <= 0:
+        raise ValueError('max_updates_per_run must be positive.')
+    checkpointing = any((checkpoint_path is not None, checkpoint_every is not None,
+                         resume, max_updates_per_run is not None))
+    if checkpointing and checkpoint_path is None:
+        checkpoint_path = save_path + '.train.pkl'
+    if history_path is None:
+        history_path = save_path + '.history.json'
+    if seed is None:
+        seed = int(np.random.SeedSequence().entropy % (2**31 - 1))
+    seed = int(seed)
+    print('# Training seed:', seed)
     if jax.device_count() > 1:
         print('# Note: Currently only one device will be used for training.')
 
@@ -168,9 +238,12 @@ def train(
     else:
         raise ValueError('model_type should be "energy", "atomic", "atomic_t2", "atomic_scalar", or "dplr".')
     data_params = {'atomic_sel':atomic_sel, 'atomic_scalar':model_type == 'atomic_scalar'}
+    dataset_rng = lambda stream: np.random.default_rng(
+        np.random.SeedSequence([seed, int(stream)]))
     train_data = Dataset(train_data_path,
                            labels,
-                           data_params)
+                           data_params,
+                           rng=dataset_rng(0))
     train_data.compute_lattice_candidate(rcut, use_neighbor_list_when_possible, mp)
     chemical_types = train_data.chemical_types
 
@@ -253,7 +326,8 @@ def train(
             single_data_obs = Dataset(obs_train_data_path[i],
                                         labels_obs,
                                         data_params,
-                                        chemical_types=chemical_types)
+                                        chemical_types=chemical_types,
+                                        rng=dataset_rng(100 + i))
             single_data_obs.fill_type(train_data.ntypes)
             single_data_obs.compute_lattice_candidate(rcut, use_neighbor_list_when_possible, mp)
             train_data_obs.append(single_data_obs)
@@ -263,7 +337,8 @@ def train(
         val_data = Dataset(val_data_path,
                              labels,
                              data_params,
-                             chemical_types=chemical_types)
+                             chemical_types=chemical_types,
+                             rng=dataset_rng(1))
         val_data.fill_type(train_data.ntypes)
         val_data.compute_lattice_candidate(rcut, use_neighbor_list_when_possible, mp)
     else:
@@ -332,8 +407,6 @@ def train(
     # initialize model variables
     batch, type_idx, lattice_args = train_data.get_batch(1)
     static_args = _get_static_args(type_idx, lattice_args)
-    if seed is None:
-        seed = np.random.randint(65536)
     variables = model.init(
                     jax.random.PRNGKey(seed),
                     batch['coord'][0],
@@ -371,8 +444,108 @@ def train(
     else:
         state = {'loss_avg': 0., 'iteration': 0}
     if hybrid:
-        _single_state_obs = {'lobs_avg': 0., 'obs_term_avg': 0., 'obs_mean': 0., 'logweights': [0.], 'ESS': 1. }
-        state_obs = {k: _single_state_obs for k in range(len(obs_train_data_path))}
+        state_obs = {
+            k: {'lobs_avg': 0., 'obs_term_avg': 0., 'obs_mean': 0.,
+                'logweights': [0.], 'ESS': 1.}
+            for k in range(len(obs_train_data_path))
+        }
+
+    model_params_raw = pickle.dumps(_tree_to_host(model.params),
+                                    protocol=pickle.HIGHEST_PROTOCOL)
+    contract = {
+        'model_type': model_type,
+        'rcut': rcut,
+        'train_data_path': _path_fingerprint(train_data_path),
+        'val_data_path': _path_fingerprint(val_data_path),
+        'step': step,
+        'mp': mp,
+        'atomic_sel': atomic_sel,
+        'embed_widths': embed_widths,
+        'embed_mp_widths': embed_mp_widths,
+        'fit_widths': fit_widths,
+        'axis_neurons': axis_neurons,
+        'lr': lr,
+        'lr_limit': lr_limit,
+        'beta2': beta2,
+        'decay_steps': decay_steps,
+        'batch_size': batch_size,
+        'val_batch_size_ratio': val_batch_size_ratio,
+        'print_every': print_every,
+        'label_bs': label_bs,
+        'loss': loss,
+        's_pref_e': s_pref_e,
+        'l_pref_e': l_pref_e,
+        's_pref_f': s_pref_f,
+        'l_pref_f': l_pref_f,
+        'seed': seed,
+        'hybrid': hybrid,
+        'obs_train_data_path': _path_fingerprint(obs_train_data_path),
+        'obs_batch_size': obs_batch_size,
+        'obs_temperature': obs_temperature,
+        'obs_target': obs_target,
+        'obs_step_every': obs_step_every,
+        'use_neighbor_list_when_possible': use_neighbor_list_when_possible,
+        'model_params_sha256': hashlib.sha256(model_params_raw).hexdigest(),
+    }
+    contract_sha256 = hashlib.sha256(
+        pickle.dumps(contract, protocol=pickle.HIGHEST_PROTOCOL)).hexdigest()
+    history = []
+
+    if resume:
+        if checkpoint_path is None or not os.path.isfile(checkpoint_path):
+            raise FileNotFoundError('Training checkpoint not found: %s' % checkpoint_path)
+        checkpoint = _load_training_checkpoint(checkpoint_path)
+        if checkpoint.get('contract_sha256') != contract_sha256:
+            checkpoint_contract = checkpoint.get('contract') or {}
+            differing_fields = sorted(
+                key for key in set(checkpoint_contract) | set(contract)
+                if pickle.dumps(checkpoint_contract.get(key),
+                                protocol=pickle.HIGHEST_PROTOCOL)
+                != pickle.dumps(contract.get(key),
+                                protocol=pickle.HIGHEST_PROTOCOL))
+            raise ValueError(
+                'Training checkpoint contract does not match this run: '
+                'checkpoint_sha256=%s run_sha256=%s differing_fields=%s.' %
+                (checkpoint.get('contract_sha256'), contract_sha256,
+                 ','.join(differing_fields) or '<unavailable>'))
+        variables = checkpoint['variables']
+        opt_state = checkpoint['opt_state']
+        state = checkpoint['state']
+        history = checkpoint.get('history', [])
+        train_data.set_sampler_state(checkpoint['train_sampler_state'])
+        if use_val_data:
+            val_data.set_sampler_state(checkpoint['val_sampler_state'])
+        if hybrid:
+            state_obs = checkpoint['state_obs']
+            for dataset, sampler_state in zip(train_data_obs,
+                                              checkpoint['obs_sampler_states']):
+                dataset.set_sampler_state(sampler_state)
+        print('# Resumed exact training state at update %d from \'%s\'.' %
+              (int(np.asarray(state['iteration'])), checkpoint_path))
+
+    def save_training_state():
+        if not checkpointing:
+            return
+        payload = {
+            'checkpoint_version': _CHECKPOINT_VERSION,
+            'contract_sha256': contract_sha256,
+            'contract': contract,
+            'variables': _tree_to_host(variables),
+            'opt_state': _tree_to_host(opt_state),
+            'state': _tree_to_host(state),
+            'history': history,
+            'train_sampler_state': train_data.get_sampler_state(),
+            'val_sampler_state': (val_data.get_sampler_state()
+                                  if use_val_data else None),
+            'state_obs': _tree_to_host(state_obs) if hybrid else None,
+            'obs_sampler_states': ([dataset.get_sampler_state()
+                                    for dataset in train_data_obs]
+                                   if hybrid else None),
+        }
+        _save_training_checkpoint(checkpoint_path, payload)
+        _write_history(history_path, history)
+        print('# Training checkpoint saved at update %d to \'%s\'.' %
+              (int(np.asarray(state['iteration'])), checkpoint_path))
 
     @partial(jax.jit, static_argnames=('static_args',))
     def train_step(batch, variables, opt_state, state, static_args):
@@ -457,46 +630,64 @@ def train(
         return ret
         
     # define print step
-    def print_step():
-        beta_smoothing = print_loss_smoothing * (1 - (1-1/print_loss_smoothing)**(iteration+1))
-        line = f'Iter {iteration:7d}'
-        L_train = state["loss_avg"] / beta_smoothing
-        line += f' L {L_train if loss == "l1-mixed" else L_train ** 0.5:7.5f}'
+    def print_step(loss_val, elapsed):
+        completed = int(np.asarray(state['iteration']))
+        beta_smoothing = print_loss_smoothing * (
+            1 - (1 - 1 / print_loss_smoothing) ** completed)
+        line = f'Update {completed:7d}'
+        record = {'update': completed,
+                  'learning_rate': float(np.asarray(lr_scheduler(completed - 1)))}
+        L_train = float(np.asarray(state["loss_avg"] / beta_smoothing))
+        L_print = L_train if loss == 'l1-mixed' else L_train ** 0.5
+        record['loss'] = L_print
+        line += f' L {L_print:7.5f}'
         if 'atomic' not in model_type:
-            LE_train = state["le_avg"] / beta_smoothing
-            LF_train = state["lf_avg"] / beta_smoothing
-            line += f' LE {LE_train if loss == "l1-mixed" else LE_train ** 0.5:7.5f}'
-            line += f' LF {LF_train if loss == "l1-mixed" else LF_train ** 0.5:7.5f}'
+            LE_train = float(np.asarray(state["le_avg"] / beta_smoothing))
+            LF_train = float(np.asarray(state["lf_avg"] / beta_smoothing))
+            LE_print = LE_train if loss == 'l1-mixed' else LE_train ** 0.5
+            LF_print = LF_train if loss == 'l1-mixed' else LF_train ** 0.5
+            record.update(energy_loss=LE_print, force_loss=LF_print)
+            line += f' LE {LE_print:7.5f}'
+            line += f' LF {LF_print:7.5f}'
         if hybrid:
             for obs_position in range(len(obs_train_data_path)):
-                line += f' LOBS{obs_position} {float(state_obs[obs_position]["lobs_avg"]):7.5f}'
-                line += f' ESS{obs_position} {float(state_obs[obs_position]["ESS"]):7.5f}'
+                lobs = float(state_obs[obs_position]["lobs_avg"])
+                ess = float(state_obs[obs_position]["ESS"])
+                record[f'observable_loss_{obs_position}'] = lobs
+                record[f'observable_ess_{obs_position}'] = ess
+                line += f' LOBS{obs_position} {lobs:7.5f}'
+                line += f' ESS{obs_position} {ess:7.5f}'
                 for obs_item  in range(len(state_obs[obs_position]["obs_term_avg"])):
-                    line += f' OBS_REW_{obs_position}_{obs_item} {float(state_obs[obs_position]["obs_term_avg"][obs_item]):7.5f}'
-                    line += f' OBS_{obs_position}_{obs_item} {float(state_obs[obs_position]["obs_mean"][obs_item]):7.5f}'
+                    obs_rew = float(state_obs[obs_position]["obs_term_avg"][obs_item])
+                    obs_mean = float(state_obs[obs_position]["obs_mean"][obs_item])
+                    record[f'observable_reweighted_{obs_position}_{obs_item}'] = obs_rew
+                    record[f'observable_mean_{obs_position}_{obs_item}'] = obs_mean
+                    line += f' OBS_REW_{obs_position}_{obs_item} {obs_rew:7.5f}'
+                    line += f' OBS_{obs_position}_{obs_item} {obs_mean:7.5f}'
         if use_val_data:
             if 'atomic' not in model_type:
-                LEval = np.array([l[0] for l in loss_val]).mean()
-                LFval = np.array([l[1] for l in loss_val]).mean()
-                line += f' LEval {LEval if loss == "l1-mixed" else LEval ** 0.5:7.5f}'
-                line += f' LFval {LFval if loss == "l1-mixed" else LFval ** 0.5:7.5f}'
+                LEval = float(np.array([l[0] for l in loss_val]).mean())
+                LFval = float(np.array([l[1] for l in loss_val]).mean())
+                LEval_print = LEval if loss == 'l1-mixed' else LEval ** 0.5
+                LFval_print = LFval if loss == 'l1-mixed' else LFval ** 0.5
+                record.update(validation_energy_loss=LEval_print,
+                              validation_force_loss=LFval_print)
+                line += f' LEval {LEval_print:7.5f}'
+                line += f' LFval {LFval_print:7.5f}'
             else:
-                Lval = np.array(loss_val).mean()
-                line += f' Lval {Lval if loss == "l1-mixed" else Lval ** 0.5:7.5f}'
-        line += f' Time {time.time() - tic:.2f}s'
+                Lval = float(np.array(loss_val).mean())
+                Lval_print = Lval if loss == 'l1-mixed' else Lval ** 0.5
+                record['validation_loss'] = Lval_print
+                line += f' Lval {Lval_print:7.5f}'
+        line += f' Time {elapsed:.2f}s'
         print(line)
+        history.append(record)
 
     # training loop
     tic = time.time()
-    for iteration in range(int(step+1)):
-        if use_val_data and iteration % print_every == 0:
-            val_batch = get_batch_val()
-            loss_val = []
-            for one_batch in val_batch:
-                v_batch, type_idx, lattice_args = one_batch
-                static_args = _get_static_args(type_idx, lattice_args)
-                loss_val.append(val_step(v_batch, variables, static_args))
-
+    segment_start = int(np.asarray(state['iteration']))
+    while int(np.asarray(state['iteration'])) < step:
+        iteration = int(np.asarray(state['iteration']))
         batch, type_idx, lattice_args = get_batch_train()
         static_args = _get_static_args(type_idx, lattice_args)
         variables, opt_state, state = train_step(batch,
@@ -518,11 +709,33 @@ def train(
                                                         static_args,
                                                         obs_position=i) 
 
-        if iteration % print_every == 0:
-            print_step()
+        completed = int(np.asarray(state['iteration']))
+        report_this_update = completed % print_every == 0 or completed == step
+        if report_this_update:
+            loss_val = None
+            if use_val_data:
+                val_batch = get_batch_val()
+                loss_val = []
+                for one_batch in val_batch:
+                    v_batch, type_idx, lattice_args = one_batch
+                    static_args = _get_static_args(type_idx, lattice_args)
+                    loss_val.append(val_step(v_batch, variables, static_args))
+            print_step(loss_val, time.time() - tic)
             tic = time.time()
 
+        if checkpoint_every is not None and completed % checkpoint_every == 0:
+            save_training_state()
+        if (max_updates_per_run is not None
+                and completed - segment_start >= max_updates_per_run
+                and completed < step):
+            save_training_state()
+            print('# Training segment stopped cleanly at update %d/%d.' %
+                  (completed, step))
+            return {'completed': False, 'completed_updates': completed,
+                    'target_updates': step, 'checkpoint_path': checkpoint_path}
+
     # compress, save, and finish
+    save_training_state()
     if compress:
         model, variables = compress_model(model,
                                                 variables,
@@ -530,6 +743,9 @@ def train(
                                                 compress_r_min)
     save_model(save_path, model, variables)
     print(f'# Training finished in {datetime.timedelta(seconds=int(time.time() - TIC))}.')
+    return {'completed': True, 'completed_updates': int(np.asarray(state['iteration'])),
+            'target_updates': step, 'model_path': save_path,
+            'checkpoint_path': checkpoint_path if checkpointing else None}
 
 
 def test(

--- a/deepmd_jax/utils.py
+++ b/deepmd_jax/utils.py
@@ -3,6 +3,7 @@ import jax
 from jax import lax, vmap, jacfwd
 import numpy as np
 import flax.linen as nn
+import hashlib
 import pickle, os
 from scipy.interpolate import PPoly, BPoly
 from jax.sharding import PartitionSpec as PSpec
@@ -224,12 +225,55 @@ def get_p3mlr_fn(box3_ref, beta, M=None, resolution=5): # PPPM long range with T
         return E
     return p3mlr_fn
 
+def _atomic_write_bytes(path, payload):
+    path = os.fspath(path)
+    parent = os.path.dirname(os.path.abspath(path))
+    os.makedirs(parent, exist_ok=True)
+    tmp = os.path.join(parent, '.%s.tmp.%d' % (os.path.basename(path), os.getpid()))
+    try:
+        with open(tmp, 'wb') as file:
+            file.write(payload)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+
+
+def _write_sha256_sidecar(path, digest):
+    sidecar = os.fspath(path) + '.sha256'
+    line = '%s  %s\n' % (digest, os.path.basename(os.fspath(path)))
+    _atomic_write_bytes(sidecar, line.encode('ascii'))
+
+
+def _verify_sha256_sidecar(path, required=False):
+    path = os.fspath(path)
+    sidecar = path + '.sha256'
+    if not os.path.isfile(sidecar):
+        if required:
+            raise ValueError("Missing SHA256 sidecar for '%s'." % path)
+        return None
+    with open(sidecar, encoding='ascii') as file:
+        fields = file.read().strip().split()
+    if len(fields) < 1 or len(fields[0]) != 64:
+        raise ValueError("Malformed SHA256 sidecar for '%s'." % path)
+    with open(path, 'rb') as file:
+        actual = hashlib.sha256(file.read()).hexdigest()
+    if actual != fields[0]:
+        raise ValueError("SHA256 mismatch for '%s'." % path)
+    return actual
+
+
 def save_model(path, model, variables):
-    with open(path, 'wb') as file:
-        pickle.dump({'model':model, 'variables':variables}, file)
+    payload = pickle.dumps({'model':model, 'variables':jax.device_get(variables)},
+                           protocol=pickle.HIGHEST_PROTOCOL)
+    _atomic_write_bytes(path, payload)
+    _write_sha256_sidecar(path, hashlib.sha256(payload).hexdigest())
     print('# Model saved to \'%s\'.' % path)
 
 def load_model(path, replicate=True):
+    _verify_sha256_sidecar(path, required=False)
     with open(path, 'rb') as file:
         m = pickle.load(file)
     print('# Model loaded from \'%s\'.' % path)

--- a/tests/test_training_resume.py
+++ b/tests/test_training_resume.py
@@ -1,4 +1,6 @@
 import json
+import hashlib
+import pickle
 import shutil
 
 import jax
@@ -6,7 +8,9 @@ import numpy as np
 import pytest
 
 from deepmd_jax.train import test as evaluate_model
-from deepmd_jax.train import train
+from deepmd_jax.train import _load_portable_model_params, train
+from deepmd_jax.data import Dataset
+from deepmd_jax.dpmodel import DPModel
 from deepmd_jax.utils import load_model
 
 
@@ -61,12 +65,95 @@ def _train_kwargs(dataset, save_path, checkpoint_path, history_path):
     )
 
 
+def _write_portable_energy_params(dataset, path):
+    train_data = Dataset(
+        str(dataset), ['coord', 'box', 'force', 'energy'],
+        {'atomic_sel': None, 'atomic_scalar': False},
+        rng=np.random.default_rng(np.random.SeedSequence([20260901, 0])))
+    train_data.compute_lattice_candidate(2.5, True, False)
+    params = {
+        'type': 'energy',
+        'atomic_data_prefix': None,
+        'embed_widths': [4, 4, 8],
+        'embedMP_widths': None,
+        'fit_widths': [8, 8],
+        'axis': 2,
+        'Ebias': train_data.fit_energy(),
+        'rcut': 2.5,
+        'use_2nd': True,
+        'use_mp': False,
+        'atomic': False,
+        'hybrid': False,
+        'nsel': None,
+        'out_norm': 1.0,
+        **train_data.get_stats(2.5, 2),
+    }
+    portable_raw = pickle.dumps(
+        jax.tree_util.tree_map(
+            lambda value: np.asarray(value) if hasattr(value, 'shape') else value,
+            DPModel(params).params),
+        protocol=pickle.HIGHEST_PROTOCOL)
+    path.write_bytes(portable_raw)
+    path.with_name(path.name + '.sha256').write_text(
+        hashlib.sha256(portable_raw).hexdigest() + f'  {path.name}\n')
+    return portable_raw
+
+
 def _assert_trees_identical(left, right):
     left_leaves = jax.tree_util.tree_leaves(left)
     right_leaves = jax.tree_util.tree_leaves(right)
     assert len(left_leaves) == len(right_leaves)
     for left_leaf, right_leaf in zip(left_leaves, right_leaves):
         np.testing.assert_array_equal(np.asarray(left_leaf), np.asarray(right_leaf))
+
+
+def _write_pickle_with_sidecar(path, payload):
+    raw = pickle.dumps(payload, protocol=pickle.HIGHEST_PROTOCOL)
+    path.write_bytes(raw)
+    digest = hashlib.sha256(raw).hexdigest()
+    path.with_name(path.name + '.sha256').write_text(
+        digest + f'  {path.name}\n')
+    return digest
+
+
+def test_portable_params_accept_measured_cpu_gpu_stat_drift(tmp_path):
+    supplied = {
+        'rcut': 6.0,
+        'Ebias': np.array([-0.7870826721191406], dtype=np.float32),
+        'sr_mean': np.array([0.06442106213018153], dtype=np.float64),
+        'sr_std': np.array([0.09724441226940518], dtype=np.float64),
+        'Nnbrs': np.float64(147.59352203147796),
+    }
+    computed = {
+        'rcut': 6.0,
+        'Ebias': supplied['Ebias'].copy(),
+        'sr_mean': np.array([0.06442605329597993], dtype=np.float64),
+        'sr_std': np.array([0.09724652347325068], dtype=np.float64),
+        'Nnbrs': np.float64(147.57904837531368),
+    }
+    path = tmp_path / 'portable.pkl'
+    digest = _write_pickle_with_sidecar(path, supplied)
+    loaded, loaded_digest = _load_portable_model_params(path, computed)
+    _assert_trees_identical(loaded, supplied)
+    assert loaded_digest == digest
+
+
+def test_portable_params_reject_larger_stat_or_contract_drift(tmp_path):
+    supplied = {
+        'rcut': 6.0,
+        'Ebias': np.array([1.0], dtype=np.float32),
+        'sr_mean': np.array([0.06], dtype=np.float64),
+        'sr_std': np.array([0.10], dtype=np.float64),
+        'Nnbrs': np.float64(150.0),
+    }
+    path = tmp_path / 'portable.pkl'
+    _write_pickle_with_sidecar(path, supplied)
+    bad_stats = dict(supplied, sr_mean=np.array([0.061], dtype=np.float64))
+    with pytest.raises(ValueError, match='local data statistics: sr_mean'):
+        _load_portable_model_params(path, bad_stats)
+    bad_contract = dict(supplied, rcut=7.5)
+    with pytest.raises(ValueError, match='model contract: rcut'):
+        _load_portable_model_params(path, bad_contract)
 
 
 def test_segment_resume_matches_continuous_training(tmp_path):
@@ -78,6 +165,8 @@ def test_segment_resume_matches_continuous_training(tmp_path):
         tmp_path / 'continuous.history.json')
     continuous_result = train(**continuous)
     assert continuous_result['completed']
+    portable_params = tmp_path / 'portable-model-params.pkl'
+    portable_raw = _write_portable_energy_params(dataset, portable_params)
 
     segmented = _train_kwargs(
         dataset, tmp_path / 'segmented.pkl', tmp_path / 'segmented.train.pkl',
@@ -90,7 +179,12 @@ def test_segment_resume_matches_continuous_training(tmp_path):
         'checkpoint_path': str(tmp_path / 'segmented.train.pkl'),
     }
     assert not (tmp_path / 'segmented.pkl').exists()
-    resumed_result = train(**segmented, resume=True)
+    with open(segmented['checkpoint_path'], 'rb') as file:
+        checkpoint = pickle.load(file)
+    assert (hashlib.sha256(portable_raw).hexdigest()
+            == checkpoint['contract']['model_params_sha256'])
+    resumed_result = train(
+        **segmented, resume=True, model_params_path=str(portable_params))
     assert resumed_result['completed']
 
     continuous_model, continuous_variables = load_model(

--- a/tests/test_training_resume.py
+++ b/tests/test_training_resume.py
@@ -1,0 +1,168 @@
+import json
+import shutil
+
+import jax
+import numpy as np
+import pytest
+
+from deepmd_jax.train import test as evaluate_model
+from deepmd_jax.train import train
+from deepmd_jax.utils import load_model
+
+
+def _write_dataset(path):
+    set_dir = path / 'set.000'
+    set_dir.mkdir(parents=True)
+    nframes = 8
+    coords = np.zeros((nframes, 3, 3), dtype=np.float32)
+    forces = np.zeros_like(coords)
+    energies = np.zeros(nframes, dtype=np.float32)
+    for frame in range(nframes):
+        x1 = 1.25 + 0.025 * frame
+        x2 = 2.70 - 0.015 * frame
+        coords[frame, :, 0] = [0.0, x1, x2]
+        d01 = x1 - 1.4
+        d12 = (x2 - x1) - 1.4
+        energies[frame] = 0.5 * (d01**2 + d12**2)
+        forces[frame, 0, 0] = d01
+        forces[frame, 1, 0] = -d01 + d12
+        forces[frame, 2, 0] = -d12
+    boxes = np.repeat(np.eye(3, dtype=np.float32)[None] * 6.0,
+                      nframes, axis=0)
+    np.savetxt(path / 'type.raw', np.zeros(3, dtype=int), fmt='%d')
+    np.save(set_dir / 'coord.npy', coords.reshape(nframes, -1))
+    np.save(set_dir / 'box.npy', boxes.reshape(nframes, -1))
+    np.save(set_dir / 'energy.npy', energies)
+    np.save(set_dir / 'force.npy', forces.reshape(nframes, -1))
+
+
+def _train_kwargs(dataset, save_path, checkpoint_path, history_path):
+    return dict(
+        model_type='energy',
+        rcut=2.5,
+        train_data_path=str(dataset),
+        val_data_path=str(dataset),
+        save_path=str(save_path),
+        checkpoint_path=str(checkpoint_path),
+        history_path=str(history_path),
+        checkpoint_every=1,
+        step=6,
+        seed=20260901,
+        mp=False,
+        embed_widths=[4, 4, 8],
+        fit_widths=[8, 8],
+        axis_neurons=2,
+        batch_size=2,
+        val_batch_size_ratio=1,
+        print_every=2,
+        getstat_bs=2,
+        compress=False,
+        loss='l2',
+    )
+
+
+def _assert_trees_identical(left, right):
+    left_leaves = jax.tree_util.tree_leaves(left)
+    right_leaves = jax.tree_util.tree_leaves(right)
+    assert len(left_leaves) == len(right_leaves)
+    for left_leaf, right_leaf in zip(left_leaves, right_leaves):
+        np.testing.assert_array_equal(np.asarray(left_leaf), np.asarray(right_leaf))
+
+
+def test_segment_resume_matches_continuous_training(tmp_path):
+    dataset = tmp_path / 'dataset'
+    _write_dataset(dataset)
+
+    continuous = _train_kwargs(
+        dataset, tmp_path / 'continuous.pkl', tmp_path / 'continuous.train.pkl',
+        tmp_path / 'continuous.history.json')
+    continuous_result = train(**continuous)
+    assert continuous_result['completed']
+
+    segmented = _train_kwargs(
+        dataset, tmp_path / 'segmented.pkl', tmp_path / 'segmented.train.pkl',
+        tmp_path / 'segmented.history.json')
+    first_result = train(**segmented, max_updates_per_run=3)
+    assert first_result == {
+        'completed': False,
+        'completed_updates': 3,
+        'target_updates': 6,
+        'checkpoint_path': str(tmp_path / 'segmented.train.pkl'),
+    }
+    assert not (tmp_path / 'segmented.pkl').exists()
+    resumed_result = train(**segmented, resume=True)
+    assert resumed_result['completed']
+
+    continuous_model, continuous_variables = load_model(
+        continuous['save_path'], replicate=False)
+    segmented_model, segmented_variables = load_model(
+        segmented['save_path'], replicate=False)
+    assert continuous_model.params == segmented_model.params
+    _assert_trees_identical(continuous_variables, segmented_variables)
+    continuous_history = json.loads(
+        (tmp_path / 'continuous.history.json').read_text())
+    segmented_history = json.loads(
+        (tmp_path / 'segmented.history.json').read_text())
+    assert continuous_history == segmented_history
+    assert [record['update'] for record in continuous_history] == [2, 4, 6]
+
+
+def test_checkpoint_hash_and_contract_fail_closed(tmp_path):
+    dataset = tmp_path / 'dataset'
+    _write_dataset(dataset)
+    kwargs = _train_kwargs(
+        dataset, tmp_path / 'model.pkl', tmp_path / 'model.train.pkl',
+        tmp_path / 'history.json')
+    result = train(**kwargs, max_updates_per_run=2)
+    assert not result['completed']
+
+    clean_checkpoint = tmp_path / 'clean.train.pkl'
+    clean_sidecar = tmp_path / 'clean.train.pkl.sha256'
+    shutil.copy2(kwargs['checkpoint_path'], clean_checkpoint)
+    shutil.copy2(kwargs['checkpoint_path'] + '.sha256', clean_sidecar)
+
+    with open(kwargs['checkpoint_path'], 'ab') as file:
+        file.write(b'corruption')
+    with pytest.raises(ValueError, match='SHA256 mismatch'):
+        train(**kwargs, resume=True)
+
+    contract_kwargs = dict(kwargs)
+    contract_kwargs['checkpoint_path'] = str(clean_checkpoint)
+    contract_kwargs['lr'] = 0.003
+    with pytest.raises(ValueError, match='differing_fields=lr'):
+        train(**contract_kwargs, resume=True)
+
+
+def test_dpmp_train_save_reload_and_test(tmp_path):
+    dataset = tmp_path / 'dataset'
+    _write_dataset(dataset)
+    model_path = tmp_path / 'dpmp.pkl'
+    result = train(
+        model_type='energy',
+        rcut=2.5,
+        train_data_path=str(dataset),
+        save_path=str(model_path),
+        step=2,
+        seed=20260902,
+        mp=True,
+        embed_widths=[4, 4, 8],
+        embed_mp_widths=[8, 8, 8],
+        fit_widths=[8, 8],
+        axis_neurons=2,
+        batch_size=2,
+        print_every=1,
+        getstat_bs=2,
+        compress=False,
+        loss='l2',
+    )
+    assert result['completed']
+    assert model_path.is_file()
+    assert (tmp_path / 'dpmp.pkl.sha256').is_file()
+    metrics, predictions = evaluate_model(str(model_path), str(dataset), batch_size=2)
+    assert len(predictions) == 8
+    assert np.isfinite(metrics['rmse']['energy'])
+    assert np.isfinite(metrics['rmse']['force'])
+    with open(model_path, 'ab') as file:
+        file.write(b'corruption')
+    with pytest.raises(ValueError, match='SHA256 mismatch'):
+        load_model(str(model_path), replicate=False)


### PR DESCRIPTION
Add full-state checkpointing so training can stop after a bounded number of updates and resume with its model parameters, Adam state, learning-rate progress, training/validation samplers, RNG states, and recorded history preserved.

- Add checkpoint_path, checkpoint_every, resume, and max_updates_per_run options.
- Make step specify the exact number of optimizer updates.
- Write checkpoints and models atomically with SHA256 sidecars; reject corrupted checkpoints and incompatible training contracts with field-level diagnostics.
- Support checksum-bound portable static model parameters, preserving their original content identity while allowing bounded CPU/GPU differences in recomputed statistics.